### PR TITLE
Changelog for 20260103

### DIFF
--- a/configs/config.example.yaml
+++ b/configs/config.example.yaml
@@ -15,6 +15,9 @@ vdr:
   host: "localhost"
   port: 6419  # Use 2001 for older VDR versions
   timeout: 10s
+  # Number of DVB cards VDR can access.
+  # Used to calculate critical timer overlaps on the Timers page.
+  dvb_cards: 1
   video_dir: "/var/lib/video.00"
   config_dir: "/etc/vdr"
   reconnect_delay: 5s

--- a/configs/config.example.yaml
+++ b/configs/config.example.yaml
@@ -18,6 +18,10 @@ vdr:
   # Number of DVB cards VDR can access.
   # Used to calculate critical timer overlaps on the Timers page.
   dvb_cards: 1
+  # If set, only these channels are shown across the UI.
+  # Leave empty to show all channels.
+  # Values are VDR channel IDs (as returned by SVDRP LSTC), e.g. "C-1-1-1".
+  wanted_channels: []
   video_dir: "/var/lib/video.00"
   config_dir: "/etc/vdr"
   reconnect_delay: 5s

--- a/internal/adapters/primary/http/server.go
+++ b/internal/adapters/primary/http/server.go
@@ -92,6 +92,8 @@ func SetupRoutes(handler *Handler, authCfg *config.AuthConfig, logger *slog.Logg
 	// Admin-only routes (write operations)
 	mux.Handle("POST /configurations/apply", chain(handler.ConfigurationsApply, adminMiddleware...))
 	mux.Handle("POST /configurations/save", chain(handler.ConfigurationsSave, adminMiddleware...))
+	mux.Handle("GET /timers/new", chain(handler.TimerNew, adminMiddleware...))
+	mux.Handle("POST /timers/new", chain(handler.TimerCreateManual, adminMiddleware...))
 	mux.Handle("GET /timers/edit", chain(handler.TimerEdit, adminMiddleware...))
 	mux.Handle("POST /timers/create", chain(handler.TimerCreate, adminMiddleware...))
 	mux.Handle("POST /timers/update", chain(handler.TimerUpdate, adminMiddleware...))

--- a/internal/adapters/primary/http/server.go
+++ b/internal/adapters/primary/http/server.go
@@ -92,7 +92,9 @@ func SetupRoutes(handler *Handler, authCfg *config.AuthConfig, logger *slog.Logg
 	// Admin-only routes (write operations)
 	mux.Handle("POST /configurations/apply", chain(handler.ConfigurationsApply, adminMiddleware...))
 	mux.Handle("POST /configurations/save", chain(handler.ConfigurationsSave, adminMiddleware...))
+	mux.Handle("GET /timers/edit", chain(handler.TimerEdit, adminMiddleware...))
 	mux.Handle("POST /timers/create", chain(handler.TimerCreate, adminMiddleware...))
+	mux.Handle("POST /timers/update", chain(handler.TimerUpdate, adminMiddleware...))
 	mux.Handle("POST /timers/toggle", chain(handler.TimerToggle, adminMiddleware...))
 	mux.Handle("DELETE /timers", chain(handler.TimerDelete, adminMiddleware...))
 	mux.Handle("POST /timers/delete", chain(handler.TimerDelete, adminMiddleware...)) // For browsers without DELETE

--- a/internal/adapters/primary/http/timer_conflict_test.go
+++ b/internal/adapters/primary/http/timer_conflict_test.go
@@ -1,0 +1,89 @@
+package http
+
+import (
+	"testing"
+	"time"
+
+	"github.com/githubixx/vdradmin-go/internal/domain"
+)
+
+func TestCriticalTimerIDs_TransponderSharing_WithOneCard(t *testing.T) {
+	day := time.Date(2026, 1, 3, 0, 0, 0, 0, time.Local)
+
+	t1 := domain.Timer{ID: 1, Active: true, ChannelID: "S19.2E-1-100-10", Start: day.Add(20 * time.Hour), Stop: day.Add(21 * time.Hour)}
+	t2 := domain.Timer{ID: 2, Active: true, ChannelID: "S19.2E-1-100-11", Start: day.Add(20*time.Hour + 10*time.Minute), Stop: day.Add(20*time.Hour + 30*time.Minute)}
+
+	crit := criticalTimerIDs([]domain.Timer{t1, t2}, 1, func(t domain.Timer) string {
+		return transponderKeyFromChannelID(t.ChannelID)
+	})
+	if len(crit) != 0 {
+		t.Fatalf("expected no critical timers (same transponder), got %v", crit)
+	}
+}
+
+func TestCriticalTimerIDs_DifferentTransponders_ExceedsCards(t *testing.T) {
+	day := time.Date(2026, 1, 3, 0, 0, 0, 0, time.Local)
+
+	t1 := domain.Timer{ID: 1, Active: true, ChannelID: "S19.2E-1-100-10", Start: day.Add(20 * time.Hour), Stop: day.Add(21 * time.Hour)}
+	t2 := domain.Timer{ID: 2, Active: true, ChannelID: "S19.2E-1-200-20", Start: day.Add(20*time.Hour + 10*time.Minute), Stop: day.Add(20*time.Hour + 30*time.Minute)}
+
+	crit := criticalTimerIDs([]domain.Timer{t1, t2}, 1, func(t domain.Timer) string {
+		return transponderKeyFromChannelID(t.ChannelID)
+	})
+	if !crit[1] || !crit[2] {
+		t.Fatalf("expected both timers critical with 1 card, got %v", crit)
+	}
+}
+
+func TestTimerOverlapStates_RecurringTimer_IsMarkedToo(t *testing.T) {
+	// Saturday 2026-01-03
+	day := time.Date(2026, 1, 3, 0, 0, 0, 0, time.Local)
+	from := day
+	to := day.Add(8 * 24 * time.Hour)
+
+	// Recurring every Saturday: start 23:00, stop 01:00
+	rec := domain.Timer{
+		ID:           10,
+		Active:       true,
+		ChannelID:     "S19.2E-1-100-10",
+		DaySpec:       "-----SS", // Sat+Sun allowed (position-based)
+		StartMinutes:  23 * 60,
+		StopMinutes:   1 * 60,
+		Priority:     50,
+		Lifetime:     99,
+		Title:        "Tuff Stuff",
+	}
+
+	// Two one-time timers on Saturday overlapping the recurring slot.
+	t1 := domain.Timer{ID: 1, Active: true, ChannelID: "S19.2E-1-200-20", Start: day.Add(20*time.Hour + 28*time.Minute), Stop: day.Add(23*time.Hour + 40*time.Minute)}
+	t2 := domain.Timer{ID: 2, Active: true, ChannelID: "S19.2E-1-300-30", Start: day.Add(22*time.Hour + 43*time.Minute), Stop: day.Add(23*time.Hour + 21*time.Minute)}
+
+	collision, critical := timerOverlapStates([]domain.Timer{rec, t1, t2}, 1, from, to, func(t domain.Timer) string {
+		return transponderKeyFromChannelID(t.ChannelID)
+	})
+
+	// With 1 DVB card and 2+ distinct transponders overlapping, all involved should be critical.
+	if !critical[10] || !critical[1] || !critical[2] {
+		t.Fatalf("expected all timers critical, got collision=%v critical=%v", collision, critical)
+	}
+}
+
+func TestTimerOverlapStates_TwoCards_TwoTransponders_IsYellowNotRed(t *testing.T) {
+	day := time.Date(2026, 1, 3, 0, 0, 0, 0, time.Local)
+	from := day
+	to := day.Add(24 * time.Hour)
+
+	t1 := domain.Timer{ID: 1, Active: true, ChannelID: "S19.2E-1-100-10", Start: day.Add(20 * time.Hour), Stop: day.Add(21 * time.Hour)}
+	t2 := domain.Timer{ID: 2, Active: true, ChannelID: "S19.2E-1-200-20", Start: day.Add(20*time.Hour + 10*time.Minute), Stop: day.Add(20*time.Hour + 30*time.Minute)}
+
+	collision, critical := timerOverlapStates([]domain.Timer{t1, t2}, 2, from, to, func(t domain.Timer) string {
+		return transponderKeyFromChannelID(t.ChannelID)
+	})
+
+	if critical[1] || critical[2] {
+		t.Fatalf("expected no critical timers with 2 cards, got %v", critical)
+	}
+	if !collision[1] || !collision[2] {
+		t.Fatalf("expected both timers collision (yellow) with overlap, got %v", collision)
+	}
+}

--- a/internal/adapters/primary/http/timer_conflicts.go
+++ b/internal/adapters/primary/http/timer_conflicts.go
@@ -1,0 +1,37 @@
+package http
+
+import (
+	"time"
+
+	"github.com/githubixx/vdradmin-go/internal/domain"
+)
+
+// criticalTimerIDs is a small helper used by tests and overlap highlighting.
+// It returns the set of timers that are in a critical overlap state (red).
+func criticalTimerIDs(timers []domain.Timer, dvbCards int, transponderKey func(domain.Timer) string) map[int]bool {
+	from, to := overlapWindowFromTimers(timers)
+	_, critical := timerOverlapStates(timers, dvbCards, from, to, transponderKey)
+	return critical
+}
+
+func overlapWindowFromTimers(timers []domain.Timer) (time.Time, time.Time) {
+	var from time.Time
+	var to time.Time
+	for _, t := range timers {
+		if t.Start.IsZero() || t.Stop.IsZero() {
+			continue
+		}
+		if from.IsZero() || t.Start.Before(from) {
+			from = t.Start
+		}
+		if to.IsZero() || t.Stop.After(to) {
+			to = t.Stop
+		}
+	}
+	if from.IsZero() {
+		now := time.Now()
+		from = now.Add(-24 * time.Hour)
+		to = now.Add(8 * 24 * time.Hour)
+	}
+	return from, to
+}

--- a/internal/adapters/primary/http/timer_create_test.go
+++ b/internal/adapters/primary/http/timer_create_test.go
@@ -1,0 +1,124 @@
+package http
+
+import (
+	"bytes"
+	"context"
+	"html/template"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/githubixx/vdradmin-go/internal/application/services"
+	"github.com/githubixx/vdradmin-go/internal/domain"
+	"github.com/githubixx/vdradmin-go/internal/infrastructure/config"
+)
+
+type timerCreateVDRMock struct {
+	mu sync.Mutex
+
+	events []domain.EPGEvent
+
+	created []*domain.Timer
+}
+
+func (m *timerCreateVDRMock) Connect(ctx context.Context) error { return nil }
+func (m *timerCreateVDRMock) Close() error                     { return nil }
+func (m *timerCreateVDRMock) Ping(ctx context.Context) error    { return nil }
+func (m *timerCreateVDRMock) GetChannels(ctx context.Context) ([]domain.Channel, error) {
+	return nil, nil
+}
+
+func (m *timerCreateVDRMock) GetEPG(ctx context.Context, channelID string, at time.Time) ([]domain.EPGEvent, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]domain.EPGEvent, len(m.events))
+	copy(out, m.events)
+	return out, nil
+}
+
+func (m *timerCreateVDRMock) GetTimers(ctx context.Context) ([]domain.Timer, error) { return nil, nil }
+
+func (m *timerCreateVDRMock) CreateTimer(ctx context.Context, timer *domain.Timer) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	cp := *timer
+	m.created = append(m.created, &cp)
+	return nil
+}
+
+func (m *timerCreateVDRMock) UpdateTimer(ctx context.Context, timer *domain.Timer) error { return nil }
+func (m *timerCreateVDRMock) DeleteTimer(ctx context.Context, timerID int) error         { return nil }
+func (m *timerCreateVDRMock) GetRecordings(ctx context.Context) ([]domain.Recording, error) {
+	return nil, nil
+}
+func (m *timerCreateVDRMock) DeleteRecording(ctx context.Context, path string) error { return nil }
+func (m *timerCreateVDRMock) GetCurrentChannel(ctx context.Context) (string, error) { return "", nil }
+func (m *timerCreateVDRMock) SetCurrentChannel(ctx context.Context, channelID string) error {
+	return nil
+}
+func (m *timerCreateVDRMock) SendKey(ctx context.Context, key string) error { return nil }
+
+func TestTimerCreate_UsesConfiguredDefaultMargins(t *testing.T) {
+	start := time.Date(2026, 1, 3, 20, 0, 0, 0, time.Local)
+	stop := time.Date(2026, 1, 3, 21, 0, 0, 0, time.Local)
+
+	mock := &timerCreateVDRMock{events: []domain.EPGEvent{{
+		EventID:   123,
+		ChannelID: "C-1-2-3",
+		Title:     "Show",
+		Start:     start,
+		Stop:      stop,
+	}}}
+
+	epgSvc := services.NewEPGService(mock, 0)
+	timerSvc := services.NewTimerService(mock)
+	recSvc := services.NewRecordingService(mock, 0)
+	autoSvc := services.NewAutoTimerService(mock, timerSvc, epgSvc)
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{}))
+	tpl := template.New("test")
+
+	h := NewHandler(logger, tpl, epgSvc, timerSvc, recSvc, autoSvc)
+	h.SetConfig(&config.Config{Timer: config.TimerConfig{
+		DefaultPriority:    50,
+		DefaultLifetime:    99,
+		DefaultMarginStart: 7,
+		DefaultMarginEnd:   11,
+	}}, "")
+
+	form := url.Values{}
+	form.Set("event_id", "123")
+	form.Set("channel", "C-1-2-3")
+
+	req := httptest.NewRequest(http.MethodPost, "/timers/create", bytes.NewBufferString(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+
+	h.TimerCreate(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusSeeOther {
+		t.Fatalf("expected %d, got %d", http.StatusSeeOther, resp.StatusCode)
+	}
+
+	mock.mu.Lock()
+	defer mock.mu.Unlock()
+	if len(mock.created) != 1 {
+		t.Fatalf("expected 1 created timer, got %d", len(mock.created))
+	}
+	created := mock.created[0]
+
+	expectedStart := start.Add(-7 * time.Minute)
+	expectedStop := stop.Add(11 * time.Minute)
+	if !created.Start.Equal(expectedStart) {
+		t.Fatalf("expected Start %s, got %s", expectedStart.Format(time.RFC3339), created.Start.Format(time.RFC3339))
+	}
+	if !created.Stop.Equal(expectedStop) {
+		t.Fatalf("expected Stop %s, got %s", expectedStop.Format(time.RFC3339), created.Stop.Format(time.RFC3339))
+	}
+}

--- a/internal/adapters/primary/http/timer_defaults_test.go
+++ b/internal/adapters/primary/http/timer_defaults_test.go
@@ -1,0 +1,41 @@
+package http
+
+import (
+	"testing"
+
+	"github.com/githubixx/vdradmin-go/internal/infrastructure/config"
+)
+
+func TestHandler_timerDefaults_FallbackWhenConfigNil(t *testing.T) {
+	h := &Handler{cfg: nil}
+	p, l, ms, me := h.timerDefaults()
+	if p != 50 || l != 99 || ms != 2 || me != 10 {
+		t.Fatalf("expected defaults 50/99/2/10, got %d/%d/%d/%d", p, l, ms, me)
+	}
+}
+
+func TestHandler_timerDefaults_UsesConfigValues(t *testing.T) {
+	h := &Handler{cfg: &config.Config{Timer: config.TimerConfig{
+		DefaultPriority:    12,
+		DefaultLifetime:    34,
+		DefaultMarginStart: 5,
+		DefaultMarginEnd:   6,
+	}}}
+	p, l, ms, me := h.timerDefaults()
+	if p != 12 || l != 34 || ms != 5 || me != 6 {
+		t.Fatalf("expected 12/34/5/6, got %d/%d/%d/%d", p, l, ms, me)
+	}
+}
+
+func TestHandler_timerDefaults_AllowsZeroMargins(t *testing.T) {
+	h := &Handler{cfg: &config.Config{Timer: config.TimerConfig{
+		DefaultPriority:    0,
+		DefaultLifetime:    0,
+		DefaultMarginStart: 0,
+		DefaultMarginEnd:   0,
+	}}}
+	p, l, ms, me := h.timerDefaults()
+	if p != 0 || l != 0 || ms != 0 || me != 0 {
+		t.Fatalf("expected 0/0/0/0, got %d/%d/%d/%d", p, l, ms, me)
+	}
+}

--- a/internal/adapters/primary/http/timer_form_test.go
+++ b/internal/adapters/primary/http/timer_form_test.go
@@ -1,0 +1,66 @@
+package http
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/githubixx/vdradmin-go/internal/domain"
+)
+
+func TestHandler_timerFromForm_OvernightStopRollsToNextDay(t *testing.T) {
+	h := &Handler{}
+
+	form := url.Values{}
+	form.Set("id", "7")
+	form.Set("active", "1")
+	form.Set("channel", "C-1-2-3")
+	form.Set("day", "2026-01-03")
+	form.Set("start", "23:30")
+	form.Set("stop", "00:30")
+	form.Set("priority", "50")
+	form.Set("lifetime", "99")
+	form.Set("title", "Overnight")
+	form.Set("aux", "")
+
+	req := &http.Request{Form: form}
+
+	timer, err := h.timerFromForm(req)
+	if err != nil {
+		t.Fatalf("timerFromForm: %v", err)
+	}
+
+	if timer.ID != 7 {
+		t.Fatalf("expected ID=7, got %d", timer.ID)
+	}
+	if timer.ChannelID != "C-1-2-3" {
+		t.Fatalf("expected channel, got %q", timer.ChannelID)
+	}
+	if timer.Title != "Overnight" {
+		t.Fatalf("expected title, got %q", timer.Title)
+	}
+
+	if timer.Start.Format("2006-01-02 15:04") != "2026-01-03 23:30" {
+		t.Fatalf("unexpected start: %s", timer.Start.Format(time.RFC3339))
+	}
+	if timer.Stop.Format("2006-01-02 15:04") != "2026-01-04 00:30" {
+		t.Fatalf("unexpected stop: %s", timer.Stop.Format(time.RFC3339))
+	}
+
+	if timer.Stop.Before(timer.Start) {
+		t.Fatalf("stop should be after start")
+	}
+}
+
+func TestHandler_timerFromForm_InvalidInput(t *testing.T) {
+	h := &Handler{}
+	form := url.Values{}
+	form.Set("id", "0")
+	req := &http.Request{Form: form}
+
+	_, err := h.timerFromForm(req)
+	if err != domain.ErrInvalidInput {
+		t.Fatalf("expected ErrInvalidInput, got %v", err)
+	}
+}

--- a/internal/adapters/primary/http/timer_new_test.go
+++ b/internal/adapters/primary/http/timer_new_test.go
@@ -1,0 +1,42 @@
+package http
+
+import (
+	"testing"
+	"time"
+
+	"github.com/githubixx/vdradmin-go/internal/domain"
+)
+
+func TestHandler_timerNewFormModel_Defaults(t *testing.T) {
+	h := &Handler{}
+
+	now := time.Date(2026, 1, 3, 15, 4, 59, 0, time.Local)
+	channels := []domain.Channel{{ID: "C-1-2-3", Name: "One"}, {ID: "C-4-5-6", Name: "Two"}}
+
+	model, selected := h.timerNewFormModel(now, channels)
+
+	if !model.Active {
+		t.Fatalf("expected Active=true")
+	}
+	if selected != "C-1-2-3" {
+		t.Fatalf("expected selected channel to be first, got %q", selected)
+	}
+	if model.Day != "2026-01-03" {
+		t.Fatalf("expected Day=2026-01-03, got %q", model.Day)
+	}
+	if model.Start != "15:04" {
+		t.Fatalf("expected Start=15:04, got %q", model.Start)
+	}
+	if model.Stop != "00:00" {
+		t.Fatalf("expected Stop=00:00, got %q", model.Stop)
+	}
+	if model.Priority != 99 || model.Lifetime != 99 {
+		t.Fatalf("expected Priority/Lifetime 99/99, got %d/%d", model.Priority, model.Lifetime)
+	}
+	if model.Title != "" {
+		t.Fatalf("expected empty Title, got %q", model.Title)
+	}
+	if model.Aux != "" {
+		t.Fatalf("expected empty Aux, got %q", model.Aux)
+	}
+}

--- a/internal/application/services/epg_service_test.go
+++ b/internal/application/services/epg_service_test.go
@@ -60,3 +60,77 @@ func TestEPGService_GetChannels_UsesCache(t *testing.T) {
 		t.Fatalf("expected 1 backend call, got %d", got)
 	}
 }
+
+func TestEPGService_WantedChannels_FiltersChannels(t *testing.T) {
+	client := &mockVDRClient{
+		GetChannelsFunc: func(ctx context.Context) ([]domain.Channel, error) {
+			return []domain.Channel{
+				{ID: "C-1-2-3", Number: 1, Name: "One"},
+				{ID: "C-9-9-9", Number: 2, Name: "Two"},
+			}, nil
+		},
+	}
+
+	svc := NewEPGService(client, 1*time.Minute)
+	svc.SetWantedChannels([]string{"C-9-9-9"})
+
+	chs, err := svc.GetChannels(context.Background())
+	if err != nil {
+		t.Fatalf("GetChannels: %v", err)
+	}
+	if len(chs) != 1 {
+		t.Fatalf("expected 1 channel, got %d", len(chs))
+	}
+	if chs[0].ID != "C-9-9-9" {
+		t.Fatalf("expected C-9-9-9, got %q", chs[0].ID)
+	}
+}
+
+func TestEPGService_WantedChannels_FiltersAllEPG(t *testing.T) {
+	client := &mockVDRClient{
+		GetEPGFunc: func(ctx context.Context, channelID string, at time.Time) ([]domain.EPGEvent, error) {
+			return []domain.EPGEvent{
+				{EventID: 1, ChannelID: "C-1-2-3", Title: "A", Start: time.Unix(10, 0), Stop: time.Unix(20, 0)},
+				{EventID: 2, ChannelID: "C-9-9-9", Title: "B", Start: time.Unix(11, 0), Stop: time.Unix(21, 0)},
+			}, nil
+		},
+	}
+
+	svc := NewEPGService(client, 1*time.Minute)
+	svc.SetWantedChannels([]string{"C-9-9-9"})
+
+	events, err := svc.GetEPG(context.Background(), "", time.Time{})
+	if err != nil {
+		t.Fatalf("GetEPG(all): %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	if events[0].ChannelID != "C-9-9-9" {
+		t.Fatalf("expected event on C-9-9-9, got %q", events[0].ChannelID)
+	}
+}
+
+func TestEPGService_WantedChannels_SkipsBackendForUnwantedChannel(t *testing.T) {
+	var calls int32
+	client := &mockVDRClient{
+		GetEPGFunc: func(ctx context.Context, channelID string, at time.Time) ([]domain.EPGEvent, error) {
+			atomic.AddInt32(&calls, 1)
+			return []domain.EPGEvent{{EventID: 1, ChannelID: channelID, Title: "X", Start: time.Unix(10, 0), Stop: time.Unix(20, 0)}}, nil
+		},
+	}
+
+	svc := NewEPGService(client, 1*time.Minute)
+	svc.SetWantedChannels([]string{"C-1-2-3"})
+
+	events, err := svc.GetEPG(context.Background(), "C-9-9-9", time.Time{})
+	if err != nil {
+		t.Fatalf("GetEPG(unwanted): %v", err)
+	}
+	if len(events) != 0 {
+		t.Fatalf("expected 0 events, got %d", len(events))
+	}
+	if got := atomic.LoadInt32(&calls); got != 0 {
+		t.Fatalf("expected 0 backend calls, got %d", got)
+	}
+}

--- a/internal/domain/models.go
+++ b/internal/domain/models.go
@@ -50,6 +50,13 @@ type Timer struct {
 	Day       time.Time
 	Start     time.Time
 	Stop      time.Time
+	// DaySpec preserves the raw VDR day specification for this timer.
+	// It is either an explicit date (e.g. "2006-01-02") or a weekday mask (e.g. "MTWTFSS" with '-' for disabled days).
+	DaySpec string
+	// StartMinutes/StopMinutes preserve the raw timer clock values as minutes since midnight.
+	// These are required for recurring timers where Start/Stop may be computed relative to a projected day.
+	StartMinutes int
+	StopMinutes  int
 	Priority  int
 	Lifetime  int // days to keep recording
 	Title     string

--- a/internal/infrastructure/config/config.go
+++ b/internal/infrastructure/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"go.yaml.in/yaml/v4"
@@ -50,6 +51,7 @@ type VDRConfig struct {
 	ConfigDir      string        `yaml:"config_dir"`
 	ReconnectDelay time.Duration `yaml:"reconnect_delay"`
 	DVBCards       int           `yaml:"dvb_cards"`
+	WantedChannels []string      `yaml:"wanted_channels"`
 }
 
 // AuthConfig contains authentication settings
@@ -96,6 +98,7 @@ func Load(path string) (*Config, error) {
 			ConfigDir:      "/etc/vdr",
 			ReconnectDelay: 5 * time.Second,
 			DVBCards:       1,
+			WantedChannels: []string{},
 		},
 		Auth: AuthConfig{
 			Enabled:      true,
@@ -159,6 +162,22 @@ func (c *Config) Validate() error {
 	if c.VDR.DVBCards < 1 || c.VDR.DVBCards > 99 {
 		return fmt.Errorf("invalid vdr dvb_cards: %d (must be 1-99)", c.VDR.DVBCards)
 	}
+
+	// Normalize wanted channels: empty means "all channels".
+	seen := map[string]struct{}{}
+	clean := make([]string, 0, len(c.VDR.WantedChannels))
+	for _, raw := range c.VDR.WantedChannels {
+		v := strings.TrimSpace(raw)
+		if v == "" {
+			continue
+		}
+		if _, ok := seen[v]; ok {
+			continue
+		}
+		seen[v] = struct{}{}
+		clean = append(clean, v)
+	}
+	c.VDR.WantedChannels = clean
 
 	if c.Server.TLS.Enabled {
 		if c.Server.TLS.CertFile == "" {

--- a/internal/infrastructure/config/config.go
+++ b/internal/infrastructure/config/config.go
@@ -49,6 +49,7 @@ type VDRConfig struct {
 	VideoDir       string        `yaml:"video_dir"`
 	ConfigDir      string        `yaml:"config_dir"`
 	ReconnectDelay time.Duration `yaml:"reconnect_delay"`
+	DVBCards       int           `yaml:"dvb_cards"`
 }
 
 // AuthConfig contains authentication settings
@@ -94,6 +95,7 @@ func Load(path string) (*Config, error) {
 			VideoDir:       "/var/lib/video.00",
 			ConfigDir:      "/etc/vdr",
 			ReconnectDelay: 5 * time.Second,
+			DVBCards:       1,
 		},
 		Auth: AuthConfig{
 			Enabled:      true,
@@ -152,6 +154,10 @@ func (c *Config) Validate() error {
 
 	if c.VDR.Host == "" {
 		return fmt.Errorf("VDR host is required")
+	}
+
+	if c.VDR.DVBCards < 1 || c.VDR.DVBCards > 99 {
+		return fmt.Errorf("invalid vdr dvb_cards: %d (must be 1-99)", c.VDR.DVBCards)
 	}
 
 	if c.Server.TLS.Enabled {

--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -528,11 +528,16 @@ main {
 /* Buttons */
 .btn {
     display: inline-block;
+    appearance: none;
+    -webkit-appearance: none;
+    -moz-appearance: none;
     padding: 0.625rem 1.25rem;
     border: 1px solid var(--border-color);
     border-radius: 999px;
     font-size: 1rem;
     font-weight: 500;
+    font-family: inherit;
+    line-height: 1.1;
     text-decoration: none;
     cursor: pointer;
     box-shadow: var(--shadow);
@@ -852,6 +857,8 @@ main {
 .config-grid input[type="text"],
 .config-grid input[type="number"],
 .config-grid input[type="password"],
+.config-grid input[type="date"],
+.config-grid input[type="time"],
 .config-grid select,
 .config-grid textarea {
     width: 100%;
@@ -861,6 +868,27 @@ main {
     font-size: 1rem;
     background: var(--surface-color);
     color: var(--text-color);
+}
+
+.timer-radio-group {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+
+.timer-radio-group label {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    font-weight: 500;
+}
+
+.timer-form-actions {
+    display: flex;
+    gap: 0.75rem;
+    align-items: center;
+    flex-wrap: wrap;
 }
 
 .config-grid input[type="checkbox"] {

--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -12,6 +12,7 @@
     --secondary-color: #64748b;
     --success-color: #10b981;
     --danger-color: #ef4444;
+    --warning-color: #f59e0b;
 
     --bg-color: #f6f7fb;
     --bg-image: radial-gradient(900px 500px at 15% 10%, rgba(124, 58, 237, 0.10), transparent 60%),
@@ -750,6 +751,16 @@ main {
 .timer-item.inactive {
     border-left-color: var(--secondary-color);
     opacity: 0.7;
+}
+
+.timer-item.collision {
+    border-left-color: var(--warning-color);
+    border-color: var(--warning-color);
+}
+
+.timer-item.conflict {
+    border-left-color: var(--danger-color);
+    border-color: var(--danger-color);
 }
 
 .timer-info h3 {

--- a/web/templates/configurations.html
+++ b/web/templates/configurations.html
@@ -107,6 +107,37 @@
                     <label for="vdr_dvb_cards">Number of DVB cards</label>
                     <input id="vdr_dvb_cards" name="vdr_dvb_cards" type="number" min="1" max="99" value="{{if .Config}}{{.Config.VDR.DVBCards}}{{end}}">
 
+                    <label for="vdr_wanted_channels">Wanted channels</label>
+                    <div>
+                        <div style="display: flex; gap: 1rem; align-items: flex-start; width: 100%;">
+                            <div style="flex: 1; min-width: 0;">
+                                <div class="empty-state" style="padding: 0 0 0.5rem 0; text-align: left;">Available (double-click to add)</div>
+                                <select id="vdr_available_channels" multiple size="12" style="width: 100%;">
+                                    {{range .AllChannels}}
+                                        {{if not (and $.WantedChannelSet (index $.WantedChannelSet .ID))}}
+                                            <option value="{{.ID}}" data-ord="{{.Number}}">{{.Number}} - {{.Name}}</option>
+                                        {{end}}
+                                    {{end}}
+                                </select>
+                            </div>
+
+                            <div style="flex: 1; min-width: 0;">
+                                <div class="empty-state" style="padding: 0 0 0.5rem 0; text-align: left;">Wanted (double-click to remove)</div>
+                                <select id="vdr_wanted_channels" name="vdr_wanted_channels" multiple size="12" style="width: 100%;">
+                                    {{range .AllChannels}}
+                                        {{if and $.WantedChannelSet (index $.WantedChannelSet .ID)}}
+                                            <option value="{{.ID}}" data-ord="{{.Number}}" selected>{{.Number}} - {{.Name}}</option>
+                                        {{end}}
+                                    {{end}}
+                                </select>
+                            </div>
+                        </div>
+
+                        <p class="empty-state" style="padding: 0.5rem 0 0 0; text-align: left;">
+                            Leave the Wanted list empty to show all channels.
+                        </p>
+                    </div>
+
                     <label for="vdr_host">Host</label>
                     <input id="vdr_host" name="vdr_host" type="text" value="{{if .Config}}{{.Config.VDR.Host}}{{end}}">
 
@@ -199,6 +230,57 @@
             <p>&copy; {{.Year}} vdradmin-go | <a href="https://github.com/githubixx/vdradmin-go">GitHub</a></p>
         </div>
     </footer>
+
+    <script>
+        (function () {
+            const available = document.getElementById('vdr_available_channels');
+            const wanted = document.getElementById('vdr_wanted_channels');
+            if (!available || !wanted) return;
+
+            function sortSelect(selectEl) {
+                const opts = Array.from(selectEl.options);
+                opts.sort((a, b) => {
+                    const oa = parseInt(a.dataset.ord || '0', 10);
+                    const ob = parseInt(b.dataset.ord || '0', 10);
+                    if (oa !== 0 && ob !== 0 && oa !== ob) return oa - ob;
+                    return a.text.localeCompare(b.text);
+                });
+                selectEl.innerHTML = '';
+                for (const o of opts) selectEl.add(o);
+            }
+
+            function moveOption(optionEl, fromSelect, toSelect, selected) {
+                optionEl.selected = selected;
+                toSelect.add(optionEl);
+                sortSelect(fromSelect);
+                sortSelect(toSelect);
+            }
+
+            available.addEventListener('dblclick', (e) => {
+                const opt = e.target;
+                if (opt && opt.tagName === 'OPTION') {
+                    moveOption(opt, available, wanted, true);
+                }
+            });
+
+            wanted.addEventListener('dblclick', (e) => {
+                const opt = e.target;
+                if (opt && opt.tagName === 'OPTION') {
+                    moveOption(opt, wanted, available, false);
+                }
+            });
+
+            // Ensure all wanted options are submitted (HTML only submits selected options).
+            const form = wanted.closest('form');
+            if (form) {
+                form.addEventListener('submit', () => {
+                    for (const opt of Array.from(wanted.options)) {
+                        opt.selected = true;
+                    }
+                });
+            }
+        })();
+    </script>
 </body>
 </html>
 {{end}}

--- a/web/templates/configurations.html
+++ b/web/templates/configurations.html
@@ -104,6 +104,9 @@
             <div class="toolbar">
                 <h3>VDR</h3>
                 <div class="config-grid">
+                    <label for="vdr_dvb_cards">Number of DVB cards</label>
+                    <input id="vdr_dvb_cards" name="vdr_dvb_cards" type="number" min="1" max="99" value="{{if .Config}}{{.Config.VDR.DVBCards}}{{end}}">
+
                     <label for="vdr_host">Host</label>
                     <input id="vdr_host" name="vdr_host" type="text" value="{{if .Config}}{{.Config.VDR.Host}}{{end}}">
 

--- a/web/templates/timer_edit.html
+++ b/web/templates/timer_edit.html
@@ -1,0 +1,91 @@
+{{define "timer_edit.html"}}
+<!DOCTYPE html>
+<html lang="en" {{if eq .ThemeMode "dark"}}data-theme="dark"{{else if eq .ThemeMode "light"}}data-theme="light"{{end}} data-theme-default="{{.ThemeDefault}}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Edit Timer - VDRAdmin-go</title>
+    <link rel="stylesheet" href="/static/css/style.css">
+</head>
+<body>
+    <header>
+        <nav class="container">
+            <div class="nav-brand">
+                <h1>VDRAdmin-go</h1>
+            </div>
+            <ul class="nav-links">
+                <li><a href="/" {{if eq .Path "/"}}class="active" aria-current="page"{{end}}>Home</a></li>
+                <li><a href="/channels" {{if eq .Path "/channels"}}class="active" aria-current="page"{{end}}>Channels</a></li>
+                <li><a href="/playing" {{if eq .Path "/playing"}}class="active" aria-current="page"{{end}}>Playing Today</a></li>
+                <li><a href="/timers" {{if eq .Path "/timers"}}class="active" aria-current="page"{{end}}>Timers</a></li>
+                <li><a href="/recordings" {{if eq .Path "/recordings"}}class="active" aria-current="page"{{end}}>Recordings</a></li>
+                <li><a href="/search" {{if eq .Path "/search"}}class="active" aria-current="page"{{end}}>Search</a></li>
+                <li><a href="/configurations" {{if eq .Path "/configurations"}}class="active" aria-current="page"{{end}}>Configurations</a></li>
+            </ul>
+            {{if .User}}
+            <div class="nav-user">
+                <span>{{.User}}</span>
+                {{if eq .Role "admin"}}<span class="badge">Admin</span>{{end}}
+            </div>
+            {{end}}
+        </nav>
+    </header>
+
+    <main class="container">
+        <div class="toolbar">
+            <h2 style="font-family: var(--font-display); font-size: 1.25rem; margin-bottom: 0.75rem;">Edit Timer</h2>
+
+            <form action="/timers/update" method="post" class="config-grid">
+                <input type="hidden" name="id" value="{{.Timer.ID}}">
+
+                <label>Timer Active</label>
+                <div class="timer-radio-group">
+                    <label><input type="radio" name="active" value="1" {{if .Timer.Active}}checked{{end}}> Yes</label>
+                    <label><input type="radio" name="active" value="0" {{if not .Timer.Active}}checked{{end}}> No</label>
+                </div>
+
+                <label for="channel">Channel</label>
+                <select id="channel" name="channel" required>
+                    {{range .Channels}}
+                    <option value="{{.ID}}" {{if eq $.SelectedChannel .ID}}selected{{end}}>{{.Name}}</option>
+                    {{end}}
+                </select>
+
+                <label for="day">Day Of Recording</label>
+                <input id="day" type="date" name="day" value="{{.Timer.Day}}" required>
+
+                <label for="start">Start Time</label>
+                <input id="start" type="text" name="start" value="{{.Timer.Start}}" inputmode="numeric" placeholder="HH:MM" pattern="^([01][0-9]|2[0-3]):[0-5][0-9]$" required>
+
+                <label for="stop">End Time</label>
+                <input id="stop" type="text" name="stop" value="{{.Timer.Stop}}" inputmode="numeric" placeholder="HH:MM" pattern="^([01][0-9]|2[0-3]):[0-5][0-9]$" required>
+
+                <label for="priority">Priority</label>
+                <input id="priority" type="number" name="priority" min="0" max="99" value="{{.Timer.Priority}}" required>
+
+                <label for="lifetime">Lifetime</label>
+                <input id="lifetime" type="number" name="lifetime" min="0" max="99" value="{{.Timer.Lifetime}}" required>
+
+                <label for="title">Title Of Recording</label>
+                <input id="title" type="text" name="title" value="{{.Timer.Title}}" required>
+
+                <label for="aux">Summary (readonly)</label>
+                <textarea id="aux" name="aux" rows="4" readonly>{{.Timer.Aux}}</textarea>
+
+                <div></div>
+                <div class="timer-form-actions">
+                    <button type="submit" class="btn btn-primary">Save</button>
+                    <a href="/timers" class="btn btn-secondary">Cancel</a>
+                </div>
+            </form>
+        </div>
+    </main>
+
+    <footer>
+        <div class="container">
+            <p>&copy; {{.Year}} vdradmin-go | <a href="https://github.com/githubixx/vdradmin-go">GitHub</a></p>
+        </div>
+    </footer>
+</body>
+</html>
+{{end}}

--- a/web/templates/timer_edit.html
+++ b/web/templates/timer_edit.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Edit Timer - VDRAdmin-go</title>
+    <title>{{if .PageTitle}}{{.PageTitle}}{{else}}Edit Timer - VDRAdmin-go{{end}}</title>
     <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>
@@ -33,10 +33,10 @@
 
     <main class="container">
         <div class="toolbar">
-            <h2 style="font-family: var(--font-display); font-size: 1.25rem; margin-bottom: 0.75rem;">Edit Timer</h2>
+            <h2 style="font-family: var(--font-display); font-size: 1.25rem; margin-bottom: 0.75rem;">{{if .Heading}}{{.Heading}}{{else}}Edit Timer{{end}}</h2>
 
-            <form action="/timers/update" method="post" class="config-grid">
-                <input type="hidden" name="id" value="{{.Timer.ID}}">
+            <form action="{{if .FormAction}}{{.FormAction}}{{else}}/timers/update{{end}}" method="post" class="config-grid">
+                {{if gt .Timer.ID 0}}<input type="hidden" name="id" value="{{.Timer.ID}}">{{end}}
 
                 <label>Timer Active</label>
                 <div class="timer-radio-group">

--- a/web/templates/timers.html
+++ b/web/templates/timers.html
@@ -34,6 +34,12 @@
 
     <main class="container">
 
+        {{if eq .Role "admin"}}
+        <div class="toolbar">
+            <a href="/timers/new" class="btn btn-primary">New Timer</a>
+        </div>
+        {{end}}
+
         <div class="timer-list">
             {{range .Timers}}
             <div class="timer-item {{if .IsRecording}}recording{{end}} {{if .Active}}active{{else}}inactive{{end}}">

--- a/web/templates/timers.html
+++ b/web/templates/timers.html
@@ -48,6 +48,7 @@
                 </div>
                 {{if eq $.Role "admin"}}
                 <div class="timer-actions">
+                    <button type="button" class="btn btn-sm btn-primary" onclick="window.location.href='/timers/edit?id={{.ID}}'">Edit</button>
                     <button
                         hx-post="/timers/toggle?id={{.ID}}"
                         hx-swap="outerHTML"

--- a/web/templates/timers.html
+++ b/web/templates/timers.html
@@ -42,7 +42,7 @@
 
         <div class="timer-list">
             {{range .Timers}}
-            <div class="timer-item {{if .IsRecording}}recording{{end}} {{if .Active}}active{{else}}inactive{{end}}">
+            <div class="timer-item {{if .IsRecording}}recording{{end}} {{if .IsCollision}}collision{{end}} {{if .IsCritical}}conflict{{end}} {{if .Active}}active{{else}}inactive{{end}}">
                 <div class="timer-info">
                     <h3>{{.Title}}</h3>
                     <div class="timer-meta">


### PR DESCRIPTION
### Timers: Edit timer
- Added an **Edit Timer** page and handler to update existing timers.
- Wired routes and updated the Timers list UI to provide an “Edit” entry.
- Added tests covering timer form parsing/validation.

### Timers: New timer (manual creation)
- Added a **New Timer** button on `/timers`.
- Added a new route to render the timer form with defaults and a POST endpoint to create a timer.
- Refactored the timer form template to be reusable for **edit vs new** by making title/heading/form action configurable.
- Added tests validating sensible default values for the New Timer form.

### Timer overlap/conflict highlighting (vdradmin-am style) + DVB cards
- Added config option `vdr.dvb_cards` (“Number of DVB cards”) with defaults and validation.
- Added Configurations UI input for `vdr.dvb_cards`.
- Implemented overlap detection on `/timers` using a vdradmin-am-like model:
  - **Yellow (collision)** when overlapping timers are still recordable given DVB cards.
  - **Red (critical)** when overlaps exceed available DVB cards.
- Improved support for **recurring timers**:
  - Extended timer parsing/model to preserve recurring weekday spec (`DaySpec`) and clock minutes (`StartMinutes`/`StopMinutes`).
  - Expanded recurring timers into occurrences in a time window so overlaps are detected correctly.
  - Ensured timer formatting preserves recurring definitions (so recurring timers aren’t broken when edited).
- Added/expanded tests for overlap logic including recurring cases and multi-card behavior.

### HTMX: prevent stale collision/conflict colors after changes
- Ensured timer delete/toggle actions trigger a full `/timers` refresh via **HTMX redirect** so remaining timers are recalculated and re-colored correctly.

### Wanted channels (global channel filtering)
- Added config option `vdr.wanted_channels` (list of VDR channel IDs).
  - Empty list means “show all channels”.
  - Normalizes values (trim + dedupe) during config validation.
- Implemented the filter centrally in `EPGService` so it applies everywhere:
  - `GetChannels()` returns only wanted channels.
  - `GetEPG("", ...)` / searches / “What’s On Now” are filtered to wanted channels.
  - Direct `GetEPG(channelID, ...)` returns empty for unwanted channels.
- Added `GetAllChannels()` for the Configurations UI (unfiltered list).
- Apply/Save updates the wanted-channel set at runtime and invalidates caches so changes take effect immediately.
- Updated Configurations UI to match vdradmin-am usability:
  - Dual lists: **Available** (left) and **Wanted** (right), always sorted in `channels.conf` order.
  - Double-click moves channels between lists (add/remove) without needing Ctrl-click.
  - On submit, all options in the Wanted list are auto-selected so the full list is posted reliably.
- Added unit tests verifying wanted-channel filtering behavior in `EPGService`.
