### PR TITLE
Improvements 20260105

### DIFF
--- a/internal/adapters/primary/http/channels_record_button_test.go
+++ b/internal/adapters/primary/http/channels_record_button_test.go
@@ -58,7 +58,10 @@ func (m *channelsVDRMock) SendKey(ctx context.Context, key string) error { retur
 
 func TestChannels_DisablesRecordOnlyForScheduledShow(t *testing.T) {
 	loc := time.Local
-	day := time.Date(2026, 1, 5, 0, 0, 0, 0, loc)
+	// Pick a day that is not "today" so the handler doesn't hide finished programs.
+	now := time.Now().In(loc)
+	day := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, loc).Add(48 * time.Hour)
+	dayStr := day.Format("2006-01-02")
 
 	ch := domain.Channel{ID: "C-1-2-3", Number: 1, Name: "SWR BW HD"}
 
@@ -125,7 +128,7 @@ func TestChannels_DisablesRecordOnlyForScheduledShow(t *testing.T) {
 	h.SetUIThemeDefault("light")
 	h.SetTemplates(map[string]*template.Template{"channels.html": parsed})
 
-	req := httptest.NewRequest(http.MethodGet, "/channels?channel="+ch.ID+"&day=2026-01-05", nil)
+	req := httptest.NewRequest(http.MethodGet, "/channels?channel="+ch.ID+"&day="+dayStr, nil)
 	ctx := context.WithValue(req.Context(), "user", "admin")
 	ctx = context.WithValue(ctx, "role", "admin")
 	req = req.WithContext(ctx)

--- a/internal/adapters/primary/http/channels_record_button_test.go
+++ b/internal/adapters/primary/http/channels_record_button_test.go
@@ -1,0 +1,184 @@
+package http
+
+import (
+	"context"
+	"html/template"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/githubixx/vdradmin-go/internal/application/services"
+	"github.com/githubixx/vdradmin-go/internal/domain"
+)
+
+type channelsVDRMock struct {
+	channels []domain.Channel
+	epqErr   error
+	epq      []domain.EPGEvent
+	timers   []domain.Timer
+}
+
+func (m *channelsVDRMock) Connect(ctx context.Context) error { return nil }
+func (m *channelsVDRMock) Close() error                      { return nil }
+func (m *channelsVDRMock) Ping(ctx context.Context) error    { return nil }
+
+func (m *channelsVDRMock) GetChannels(ctx context.Context) ([]domain.Channel, error) {
+	return m.channels, nil
+}
+
+func (m *channelsVDRMock) GetEPG(ctx context.Context, channelID string, at time.Time) ([]domain.EPGEvent, error) {
+	if m.epqErr != nil {
+		return nil, m.epqErr
+	}
+	return m.epq, nil
+}
+
+func (m *channelsVDRMock) GetTimers(ctx context.Context) ([]domain.Timer, error) {
+	return m.timers, nil
+}
+
+func (m *channelsVDRMock) CreateTimer(ctx context.Context, timer *domain.Timer) error { return nil }
+func (m *channelsVDRMock) UpdateTimer(ctx context.Context, timer *domain.Timer) error { return nil }
+func (m *channelsVDRMock) DeleteTimer(ctx context.Context, timerID int) error         { return nil }
+
+func (m *channelsVDRMock) GetRecordings(ctx context.Context) ([]domain.Recording, error) {
+	return nil, nil
+}
+func (m *channelsVDRMock) DeleteRecording(ctx context.Context, path string) error { return nil }
+func (m *channelsVDRMock) GetCurrentChannel(ctx context.Context) (string, error)  { return "", nil }
+func (m *channelsVDRMock) SetCurrentChannel(ctx context.Context, channelID string) error {
+	return nil
+}
+func (m *channelsVDRMock) SendKey(ctx context.Context, key string) error { return nil }
+
+func TestChannels_DisablesRecordOnlyForScheduledShow(t *testing.T) {
+	loc := time.Local
+	day := time.Date(2026, 1, 5, 0, 0, 0, 0, loc)
+
+	ch := domain.Channel{ID: "C-1-2-3", Number: 1, Name: "SWR BW HD"}
+
+	scheduled := domain.EPGEvent{
+		EventID:       100,
+		ChannelID:     ch.ID,
+		ChannelNumber: ch.Number,
+		ChannelName:   ch.Name,
+		Title:         "Landesschau Baden-Württemberg",
+		Start:         day.Add(9*time.Hour + 10*time.Minute),
+		Stop:          day.Add(10*time.Hour + 25*time.Minute),
+	}
+	before := domain.EPGEvent{
+		EventID:       99,
+		ChannelID:     ch.ID,
+		ChannelNumber: ch.Number,
+		ChannelName:   ch.Name,
+		Title:         "Panoramablick",
+		Start:         day.Add(7*time.Hour + 55*time.Minute),
+		Stop:          day.Add(9*time.Hour + 10*time.Minute),
+	}
+	after := domain.EPGEvent{
+		EventID:       101,
+		ChannelID:     ch.ID,
+		ChannelNumber: ch.Number,
+		ChannelName:   ch.Name,
+		Title:         "Eisenbahn-Romantik (503)",
+		Start:         day.Add(10*time.Hour + 25*time.Minute),
+		Stop:          day.Add(10*time.Hour + 55*time.Minute),
+	}
+
+	// Timer has margins that overlap neighboring shows.
+	timer := domain.Timer{
+		ID:        1,
+		Active:    true,
+		ChannelID: ch.ID,
+		Title:     scheduled.Title,
+		Start:     scheduled.Start.Add(-2 * time.Minute),
+		Stop:      scheduled.Stop.Add(10 * time.Minute),
+	}
+
+	mock := &channelsVDRMock{
+		channels: []domain.Channel{ch},
+		epq:      []domain.EPGEvent{before, scheduled, after},
+		timers:   []domain.Timer{timer},
+	}
+
+	epqService := services.NewEPGService(mock, 0)
+	timerService := services.NewTimerService(mock)
+
+	parsed := template.Must(template.ParseFiles(
+		filepath.Join(repoRoot(t), "web", "templates", "_nav.html"),
+		filepath.Join(repoRoot(t), "web", "templates", "channels.html"),
+	))
+
+	h := NewHandler(
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+		parsed,
+		epqService,
+		timerService,
+		nil,
+		nil,
+	)
+	h.SetUIThemeDefault("light")
+	h.SetTemplates(map[string]*template.Template{"channels.html": parsed})
+
+	req := httptest.NewRequest(http.MethodGet, "/channels?channel="+ch.ID+"&day=2026-01-05", nil)
+	ctx := context.WithValue(req.Context(), "user", "admin")
+	ctx = context.WithValue(ctx, "role", "admin")
+	req = req.WithContext(ctx)
+
+	rw := httptest.NewRecorder()
+	h.Channels(rw, req)
+
+	if rw.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rw.Code)
+	}
+
+	body := rw.Body.String()
+	const recordForm = "<form method=\"post\" action=\"/timers/create\""
+	const scheduledButton = "disabled>Scheduled</button>"
+
+	beforeIdx := strings.Index(body, before.Title)
+	scheduledIdx := strings.Index(body, scheduled.Title)
+	afterIdx := strings.Index(body, after.Title)
+
+	if beforeIdx == -1 {
+		t.Fatalf("expected to find before show title in HTML")
+	}
+	if scheduledIdx == -1 {
+		t.Fatalf("expected to find scheduled show title in HTML")
+	}
+	if afterIdx == -1 {
+		t.Fatalf("expected to find after show title in HTML")
+	}
+	if !(beforeIdx < scheduledIdx && scheduledIdx < afterIdx) {
+		t.Fatalf("expected shows to render in EPG order (before < scheduled < after)")
+	}
+
+	beforeSeg := body[beforeIdx:scheduledIdx]
+	scheduledSeg := body[scheduledIdx:afterIdx]
+	afterSeg := body[afterIdx:]
+
+	if !strings.Contains(beforeSeg, recordForm) {
+		t.Fatalf("expected before show to remain recordable")
+	}
+	if !strings.Contains(afterSeg, recordForm) {
+		t.Fatalf("expected after show to remain recordable")
+	}
+	if !strings.Contains(scheduledSeg, scheduledButton) {
+		t.Fatalf("expected scheduled show to be marked Scheduled")
+	}
+	if strings.Contains(scheduledSeg, recordForm) {
+		t.Fatalf("expected scheduled show not to render a record form")
+	}
+
+	if got := strings.Count(body, scheduledButton); got != 1 {
+		t.Fatalf("expected exactly 1 scheduled button, got %d", got)
+	}
+	if got := strings.Count(body, recordForm); got != 2 {
+		t.Fatalf("expected exactly 2 record forms (before/after), got %d", got)
+	}
+}

--- a/internal/adapters/primary/http/channels_record_button_test.go
+++ b/internal/adapters/primary/http/channels_record_button_test.go
@@ -211,15 +211,21 @@ func (m *channelsEPGAtSpyVDRMock) GetTimers(ctx context.Context) ([]domain.Timer
 	return []domain.Timer{}, nil
 }
 
-func (m *channelsEPGAtSpyVDRMock) CreateTimer(ctx context.Context, timer *domain.Timer) error { return nil }
-func (m *channelsEPGAtSpyVDRMock) UpdateTimer(ctx context.Context, timer *domain.Timer) error { return nil }
-func (m *channelsEPGAtSpyVDRMock) DeleteTimer(ctx context.Context, timerID int) error         { return nil }
+func (m *channelsEPGAtSpyVDRMock) CreateTimer(ctx context.Context, timer *domain.Timer) error {
+	return nil
+}
+func (m *channelsEPGAtSpyVDRMock) UpdateTimer(ctx context.Context, timer *domain.Timer) error {
+	return nil
+}
+func (m *channelsEPGAtSpyVDRMock) DeleteTimer(ctx context.Context, timerID int) error { return nil }
 
 func (m *channelsEPGAtSpyVDRMock) GetRecordings(ctx context.Context) ([]domain.Recording, error) {
 	return nil, nil
 }
 func (m *channelsEPGAtSpyVDRMock) DeleteRecording(ctx context.Context, path string) error { return nil }
-func (m *channelsEPGAtSpyVDRMock) GetCurrentChannel(ctx context.Context) (string, error)  { return "", nil }
+func (m *channelsEPGAtSpyVDRMock) GetCurrentChannel(ctx context.Context) (string, error) {
+	return "", nil
+}
 func (m *channelsEPGAtSpyVDRMock) SetCurrentChannel(ctx context.Context, channelID string) error {
 	return nil
 }

--- a/internal/adapters/primary/http/epgsearch_run_test.go
+++ b/internal/adapters/primary/http/epgsearch_run_test.go
@@ -1,0 +1,283 @@
+package http
+
+import (
+	"context"
+	"html/template"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/githubixx/vdradmin-go/internal/application/services"
+	"github.com/githubixx/vdradmin-go/internal/domain"
+)
+
+type epgsearchRunVDRMock struct {
+	channels []domain.Channel
+	epq      []domain.EPGEvent
+	timers   []domain.Timer
+}
+
+func (m *epgsearchRunVDRMock) Connect(ctx context.Context) error { return nil }
+func (m *epgsearchRunVDRMock) Close() error                      { return nil }
+func (m *epgsearchRunVDRMock) Ping(ctx context.Context) error    { return nil }
+
+func (m *epgsearchRunVDRMock) GetChannels(ctx context.Context) ([]domain.Channel, error) {
+	return m.channels, nil
+}
+
+func (m *epgsearchRunVDRMock) GetEPG(ctx context.Context, channelID string, at time.Time) ([]domain.EPGEvent, error) {
+	// For this test we always return the full set; filtering is done by the handler/services.
+	return m.epq, nil
+}
+
+func (m *epgsearchRunVDRMock) GetTimers(ctx context.Context) ([]domain.Timer, error) {
+	return m.timers, nil
+}
+
+func (m *epgsearchRunVDRMock) CreateTimer(ctx context.Context, timer *domain.Timer) error { return nil }
+func (m *epgsearchRunVDRMock) UpdateTimer(ctx context.Context, timer *domain.Timer) error { return nil }
+func (m *epgsearchRunVDRMock) DeleteTimer(ctx context.Context, timerID int) error         { return nil }
+
+func (m *epgsearchRunVDRMock) GetRecordings(ctx context.Context) ([]domain.Recording, error) {
+	return nil, nil
+}
+func (m *epgsearchRunVDRMock) DeleteRecording(ctx context.Context, path string) error { return nil }
+func (m *epgsearchRunVDRMock) GetCurrentChannel(ctx context.Context) (string, error)  { return "", nil }
+func (m *epgsearchRunVDRMock) SetCurrentChannel(ctx context.Context, channelID string) error {
+	return nil
+}
+func (m *epgsearchRunVDRMock) SendKey(ctx context.Context, key string) error { return nil }
+
+func TestEPGSearchNew_RunRendersMatchesAndRecordPrefillLink(t *testing.T) {
+	loc := time.Local
+	eventStart := time.Date(2026, 1, 7, 0, 0, 0, 0, loc)
+	eventStop := time.Date(2026, 1, 7, 1, 30, 0, 0, loc)
+
+	ch := domain.Channel{ID: "C-1-2-3", Number: 1, Name: "SWR BW HD"}
+	ev := domain.EPGEvent{
+		EventID:       123,
+		ChannelID:     ch.ID,
+		ChannelNumber: ch.Number,
+		ChannelName:   ch.Name,
+		Title:         "Familie Heinz Becker - Lachgeschichten",
+		Start:         eventStart,
+		Stop:          eventStop,
+	}
+
+	mock := &epgsearchRunVDRMock{
+		channels: []domain.Channel{ch},
+		epq:      []domain.EPGEvent{ev},
+	}
+	EPG := services.NewEPGService(mock, 0)
+	Timers := services.NewTimerService(mock)
+
+	parsed := template.Must(template.ParseFiles(
+		filepath.Join(repoRoot(t), "web", "templates", "_nav.html"),
+		filepath.Join(repoRoot(t), "web", "templates", "epgsearch_edit.html"),
+	))
+
+	h := NewHandler(
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+		parsed,
+		EPG,
+		Timers,
+		nil,
+		nil,
+	)
+	h.SetUIThemeDefault("light")
+	h.SetTemplates(map[string]*template.Template{"epgsearch_edit.html": parsed})
+
+	form := url.Values{}
+	form.Set("action", "run")
+	form.Set("active", "on")
+	form.Set("pattern", "Heinz")
+	form.Set("mode", "phrase")
+	form.Set("in_title", "on")
+	form.Set("in_subtitle", "on")
+	form.Set("in_description", "on")
+	form.Set("use_channel", "no")
+
+	req := httptest.NewRequest(http.MethodPost, "/epgsearch/new", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	ctx := context.WithValue(req.Context(), "user", "admin")
+	ctx = context.WithValue(ctx, "role", "admin")
+	req = req.WithContext(ctx)
+
+	rw := httptest.NewRecorder()
+	h.EPGSearchCreate(rw, req)
+
+	if rw.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rw.Code)
+	}
+
+	body := rw.Body.String()
+	mustContain(t, body, "Add New Search")
+	mustContain(t, body, "Matches")
+	mustContain(t, body, ev.Title)
+	mustContain(t, body, "value=\"Heinz\"")
+
+	mustContain(t, body, "/timers/new?channel="+url.QueryEscape(ch.ID))
+	mustContain(t, body, "title=")
+	mustContain(t, body, "day=2026-01-07")
+	mustContain(t, body, "start=00")
+	mustContain(t, body, "stop=01")
+}
+
+func TestEPGSearchNew_RunMarksMidnightMatchAsScheduledWithNumericChannelTimer(t *testing.T) {
+	loc := time.Local
+	eventStart := time.Date(2026, 1, 7, 0, 0, 0, 0, loc)
+	eventStop := time.Date(2026, 1, 7, 1, 30, 0, 0, loc)
+
+	ch := domain.Channel{ID: "C-1-2-3", Number: 1, Name: "SWR BW HD"}
+	ev := domain.EPGEvent{
+		EventID:       123,
+		ChannelID:     ch.ID,
+		ChannelNumber: 0, // simulate missing numeric channel metadata in EPG output
+		ChannelName:   ch.Name,
+		Title:         "Familie Heinz Becker - Lachgeschichten",
+		Start:         eventStart,
+		Stop:          eventStop,
+	}
+
+	// Timer created with margins that start on the previous day, and stored using the numeric
+	// channel reference (as VDR often does). Should still mark the midnight event as scheduled.
+	timer := domain.Timer{
+		ID:        42,
+		Active:    true,
+		ChannelID: "1",
+		Title:     ev.Title,
+		Start:     time.Date(2026, 1, 6, 23, 58, 0, 0, loc),
+		Stop:      time.Date(2026, 1, 7, 1, 40, 0, 0, loc),
+	}
+
+	mock := &epgsearchRunVDRMock{
+		channels: []domain.Channel{ch},
+		epq:      []domain.EPGEvent{ev},
+		timers:   []domain.Timer{timer},
+	}
+	EPG := services.NewEPGService(mock, 0)
+	Timers := services.NewTimerService(mock)
+
+	parsed := template.Must(template.ParseFiles(
+		filepath.Join(repoRoot(t), "web", "templates", "_nav.html"),
+		filepath.Join(repoRoot(t), "web", "templates", "epgsearch_edit.html"),
+	))
+
+	h := NewHandler(
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+		parsed,
+		EPG,
+		Timers,
+		nil,
+		nil,
+	)
+	h.SetUIThemeDefault("light")
+	h.SetTemplates(map[string]*template.Template{"epgsearch_edit.html": parsed})
+
+	form := url.Values{}
+	form.Set("action", "run")
+	form.Set("active", "on")
+	form.Set("pattern", "Heinz")
+	form.Set("mode", "phrase")
+	form.Set("in_title", "on")
+	form.Set("in_subtitle", "on")
+	form.Set("in_description", "on")
+	form.Set("use_channel", "no")
+
+	req := httptest.NewRequest(http.MethodPost, "/epgsearch/new", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	ctx := context.WithValue(req.Context(), "user", "admin")
+	ctx = context.WithValue(ctx, "role", "admin")
+	req = req.WithContext(ctx)
+
+	rw := httptest.NewRecorder()
+	h.EPGSearchCreate(rw, req)
+
+	if rw.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rw.Code)
+	}
+
+	body := rw.Body.String()
+	mustContain(t, body, ev.Title)
+	mustContain(t, body, "Scheduled")
+	if strings.Contains(body, "/timers/new?channel=") {
+		t.Fatalf("expected no Record link when scheduled; got %q", body)
+	}
+}
+
+func TestEPGSearchEdit_RunRendersMatches(t *testing.T) {
+	loc := time.Local
+	eventStart := time.Date(2026, 1, 7, 0, 0, 0, 0, loc)
+	eventStop := time.Date(2026, 1, 7, 1, 30, 0, 0, loc)
+
+	ch := domain.Channel{ID: "C-1-2-3", Number: 1, Name: "SWR BW HD"}
+	ev := domain.EPGEvent{
+		EventID:       123,
+		ChannelID:     ch.ID,
+		ChannelNumber: ch.Number,
+		ChannelName:   ch.Name,
+		Title:         "Familie Heinz Becker - Lachgeschichten",
+		Start:         eventStart,
+		Stop:          eventStop,
+	}
+
+	mock := &epgsearchRunVDRMock{
+		channels: []domain.Channel{ch},
+		epq:      []domain.EPGEvent{ev},
+	}
+	EPG := services.NewEPGService(mock, 0)
+	Timers := services.NewTimerService(mock)
+
+	parsed := template.Must(template.ParseFiles(
+		filepath.Join(repoRoot(t), "web", "templates", "_nav.html"),
+		filepath.Join(repoRoot(t), "web", "templates", "epgsearch_edit.html"),
+	))
+
+	h := NewHandler(
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+		parsed,
+		EPG,
+		Timers,
+		nil,
+		nil,
+	)
+	// EPGSearchUpdate requires a cfg for save, but action=run should work without it.
+	h.SetUIThemeDefault("light")
+	h.SetTemplates(map[string]*template.Template{"epgsearch_edit.html": parsed})
+
+	form := url.Values{}
+	form.Set("action", "run")
+	form.Set("id", "1")
+	form.Set("active", "on")
+	form.Set("pattern", "Heinz")
+	form.Set("mode", "phrase")
+	form.Set("in_title", "on")
+	form.Set("in_subtitle", "on")
+	form.Set("in_description", "on")
+	form.Set("use_channel", "no")
+
+	req := httptest.NewRequest(http.MethodPost, "/epgsearch/edit", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	ctx := context.WithValue(req.Context(), "user", "admin")
+	ctx = context.WithValue(ctx, "role", "admin")
+	req = req.WithContext(ctx)
+
+	rw := httptest.NewRecorder()
+	h.EPGSearchUpdate(rw, req)
+
+	if rw.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rw.Code)
+	}
+
+	body := rw.Body.String()
+	mustContain(t, body, "Edit Search")
+	mustContain(t, body, "Matches")
+	mustContain(t, body, ev.Title)
+	mustContain(t, body, "value=\"Heinz\"")
+}

--- a/internal/adapters/primary/http/epgsearch_template_test.go
+++ b/internal/adapters/primary/http/epgsearch_template_test.go
@@ -57,8 +57,57 @@ func TestTemplate_EPGSearchEdit_HasFormAndGlossyButtons(t *testing.T) {
 	mustContain(t, html, "<form")
 	mustContain(t, html, "class=\"config-grid\"")
 	mustContain(t, html, "action=\"/epgsearch/new\"")
-	mustContain(t, html, "<button type=\"submit\" class=\"btn btn-primary\">Save</button>")
+	mustContain(t, html, "<button type=\"submit\" name=\"action\" value=\"save\" class=\"btn btn-primary\">Save</button>")
+	mustContain(t, html, "<button type=\"submit\" name=\"action\" value=\"run\" class=\"btn btn-secondary\">Run</button>")
 	mustContain(t, html, "<a href=\"/epgsearch\" class=\"btn btn-secondary\">Cancel</a>")
+
+	saveIdx := bytes.Index([]byte(html), []byte("value=\"save\""))
+	runIdx := bytes.Index([]byte(html), []byte("value=\"run\""))
+	cancelIdx := bytes.Index([]byte(html), []byte(">Cancel</a>"))
+	if saveIdx == -1 || runIdx == -1 || cancelIdx == -1 {
+		t.Fatalf("expected Save/Run/Cancel controls to be present")
+	}
+	if !(saveIdx < runIdx && runIdx < cancelIdx) {
+		t.Fatalf("expected button order Save -> Run -> Cancel")
+	}
+}
+
+func TestTemplate_EPGSearchEdit_ShowsRunButtonOnEdit(t *testing.T) {
+	tmpl := template.Must(template.ParseFiles(
+		filepath.Join(repoRoot(t), "web", "templates", "_nav.html"),
+		filepath.Join(repoRoot(t), "web", "templates", "epgsearch_edit.html"),
+	))
+
+	data := map[string]any{
+		"User":         "admin",
+		"Role":         "admin",
+		"Year":         2026,
+		"Path":         "/epgsearch/edit?id=1",
+		"ThemeDefault": "light",
+		"ThemeMode":    "light",
+		"Heading":      "Edit Search",
+		"PageTitle":    "Edit Search - VDRAdmin-go",
+		"FormAction":   "/epgsearch/edit",
+		"Search": config.EPGSearch{
+			ID:         1,
+			Active:     true,
+			Mode:       "phrase",
+			InTitle:    true,
+			InSubtitle: true,
+			InDesc:     true,
+			UseChannel: "no",
+		},
+		"Channels": []struct{}{},
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.ExecuteTemplate(&buf, "epgsearch_edit.html", data); err != nil {
+		t.Fatalf("execute template: %v", err)
+	}
+
+	html := buf.String()
+	mustContain(t, html, "action=\"/epgsearch/edit\"")
+	mustContain(t, html, "<button type=\"submit\" name=\"action\" value=\"run\" class=\"btn btn-secondary\">Run</button>")
 }
 
 func repoRoot(t *testing.T) string {

--- a/internal/adapters/primary/http/handlers.go
+++ b/internal/adapters/primary/http/handlers.go
@@ -622,18 +622,6 @@ func (h *Handler) buildConfigFromForm(form url.Values) (*config.Config, error) {
 	return &updated, nil
 }
 
-func setThemeCookie(w http.ResponseWriter, theme string) {
-	theme = normalizeTheme(strings.TrimSpace(theme))
-	// Persist explicit mode (including system) for a long time.
-	http.SetCookie(w, &http.Cookie{
-		Name:     "theme",
-		Value:    url.QueryEscape(theme),
-		Path:     "/",
-		MaxAge:   60 * 60 * 24 * 365,
-		SameSite: http.SameSiteLaxMode,
-	})
-}
-
 func parseLines(raw string) []string {
 	raw = strings.ReplaceAll(raw, ",", "\n")
 	parts := strings.Split(raw, "\n")

--- a/internal/adapters/primary/http/handlers.go
+++ b/internal/adapters/primary/http/handlers.go
@@ -161,6 +161,17 @@ func (h *Handler) Channels(w http.ResponseWriter, r *http.Request) {
 	dayEnd := dayStart.Add(24 * time.Hour)
 	data["SelectedDay"] = dayStart.Format("2006-01-02")
 
+	numberByID := make(map[string]int, len(channels))
+	idByNumber := make(map[int]string, len(channels))
+	for _, ch := range channels {
+		if ch.ID != "" {
+			numberByID[ch.ID] = ch.Number
+		}
+		if ch.Number > 0 && ch.ID != "" {
+			idByNumber[ch.Number] = ch.ID
+		}
+	}
+
 	var events []domain.EPGEvent
 	daysByValue := map[string]time.Time{}
 	// Always include selected day in the dropdown.
@@ -233,59 +244,9 @@ func (h *Handler) Channels(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	normalizeTitle := func(s string) string {
-		s = strings.ToLower(strings.TrimSpace(s))
-		s = strings.Join(strings.Fields(s), " ")
-		return s
-	}
-
 	eventScheduled := func(ev domain.EPGEvent) bool {
-		evTitle := normalizeTitle(ev.Title)
-		if evTitle == "" {
-			return false
-		}
-
-		lookupOccs := func() []timerOccurrence {
-			if ev.ChannelNumber > 0 {
-				if occs := occByChannelNumber[ev.ChannelNumber]; len(occs) > 0 {
-					return occs
-				}
-			}
-			if ev.ChannelID != "" {
-				if occs := occByChannelID[ev.ChannelID]; len(occs) > 0 {
-					return occs
-				}
-				if ev.ChannelNumber > 0 {
-					if occs := occByChannelID[strconv.Itoa(ev.ChannelNumber)]; len(occs) > 0 {
-						return occs
-					}
-				}
-			}
-			return nil
-		}
-
-		occs := lookupOccs()
-		if len(occs) == 0 {
-			return false
-		}
-		evStart := ev.Start.In(time.Local)
-		evStop := ev.Stop.In(time.Local)
-		if evStop.Before(evStart) {
-			evStop = evStart
-		}
-		for _, occ := range occs {
-			if !occ.Start.Before(evStop) || !evStart.Before(occ.Stop) {
-				continue
-			}
-			t, ok := timersByID[occ.TimerID]
-			if !ok {
-				continue
-			}
-			if normalizeTitle(t.Title) == evTitle {
-				return true
-			}
-		}
-		return false
+		_, ok := scheduledTimerForEvent(ev, loc, occByChannelNumber, occByChannelID, numberByID, idByNumber, timersByID)
+		return ok
 	}
 
 	dayOptions := make([]channelsDayOption, 0, len(daysByValue))
@@ -779,73 +740,9 @@ func (h *Handler) PlayingToday(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	normalizeTitle := func(s string) string {
-		s = strings.ToLower(strings.TrimSpace(s))
-		s = strings.Join(strings.Fields(s), " ")
-		return s
-	}
-
 	hasOverlappingActiveTimer := func(ev domain.EPGEvent) bool {
-		evTitle := normalizeTitle(ev.Title)
-		if evTitle == "" {
-			return false
-		}
-		lookupOccs := func() []timerOccurrence {
-			if ev.ChannelNumber > 0 {
-				if occs := occByChannelNumber[ev.ChannelNumber]; len(occs) > 0 {
-					return occs
-				}
-			}
-			if ev.ChannelID != "" {
-				if ev.ChannelNumber <= 0 {
-					if n := numberByID[ev.ChannelID]; n > 0 {
-						if occs := occByChannelNumber[n]; len(occs) > 0 {
-							return occs
-						}
-					}
-				}
-				if occs := occByChannelID[ev.ChannelID]; len(occs) > 0 {
-					return occs
-				}
-				if ev.ChannelNumber > 0 {
-					if occs := occByChannelID[strconv.Itoa(ev.ChannelNumber)]; len(occs) > 0 {
-						return occs
-					}
-				}
-			}
-			if ev.ChannelNumber > 0 {
-				if id := idByNumber[ev.ChannelNumber]; id != "" {
-					if occs := occByChannelID[id]; len(occs) > 0 {
-						return occs
-					}
-				}
-			}
-			return nil
-		}
-
-		occs := lookupOccs()
-		if len(occs) == 0 {
-			return false
-		}
-
-		evStart := ev.Start.In(loc)
-		evStop := ev.Stop.In(loc)
-		if evStop.Before(evStart) {
-			evStop = evStart
-		}
-		for _, occ := range occs {
-			if !occ.Start.Before(evStop) || !evStart.Before(occ.Stop) {
-				continue
-			}
-			t, ok := timersByID[occ.TimerID]
-			if !ok {
-				continue
-			}
-			if normalizeTitle(t.Title) == evTitle {
-				return true
-			}
-		}
-		return false
+		_, ok := scheduledTimerForEvent(ev, loc, occByChannelNumber, occByChannelID, numberByID, idByNumber, timersByID)
+		return ok
 	}
 
 	groups := make([]playingChannelGroup, 0, len(channels))
@@ -1147,7 +1044,7 @@ func (h *Handler) EPGSearchExecute(w http.ResponseWriter, r *http.Request) {
 			h.logger.Warn("timers fetch error for epgsearch results", slog.Any("error", tErr))
 		} else {
 			for _, t := range timers {
-				if !t.Active || strings.TrimSpace(t.ChannelID) == "" {
+				if strings.TrimSpace(t.ChannelID) == "" {
 					continue
 				}
 				timersByID[t.ID] = t
@@ -1290,64 +1187,12 @@ func (h *Handler) EPGSearchExecute(w http.ResponseWriter, r *http.Request) {
 
 		label := "---"
 		active := false
-		lookupOccs := func() []timerOccurrence {
-			if ev.ChannelNumber > 0 {
-				if occs := occByChannelNumber[ev.ChannelNumber]; len(occs) > 0 {
-					return occs
-				}
-			}
-			if ev.ChannelID != "" {
-				// Some VDR/SVDRP outputs don't provide the numeric channel in the EPG header.
-				// When that happens, map the derived channel id -> number via the channels list.
-				if ev.ChannelNumber <= 0 {
-					if n := numberByID[ev.ChannelID]; n > 0 {
-						if occs := occByChannelNumber[n]; len(occs) > 0 {
-							return occs
-						}
-					}
-				}
-				if occs := occByChannelID[ev.ChannelID]; len(occs) > 0 {
-					return occs
-				}
-				// Sometimes timers are indexed by numeric channel id string.
-				if ev.ChannelNumber > 0 {
-					if occs := occByChannelID[strconv.Itoa(ev.ChannelNumber)]; len(occs) > 0 {
-						return occs
-					}
-				}
-			}
-			// Last resort: if we can map number->id, try that.
-			if ev.ChannelNumber > 0 {
-				if id := idByNumber[ev.ChannelNumber]; id != "" {
-					if occs := occByChannelID[id]; len(occs) > 0 {
-						return occs
-					}
-				}
-			}
-			return nil
-		}
-
-		if occs := lookupOccs(); len(occs) > 0 {
-			evStart := ev.Start.In(loc)
-			evStop := ev.Stop.In(loc)
-			if evStop.Before(evStart) {
-				evStop = evStart
-			}
-			for _, occ := range occs {
-				// overlap if: occ.Start < evStop && evStart < occ.Stop
-				if occ.Start.Before(evStop) && evStart.Before(occ.Stop) {
-					active = true
-					if t, ok := timersByID[occ.TimerID]; ok {
-						if strings.TrimSpace(t.Title) != "" {
-							label = t.Title
-						} else {
-							label = "active"
-						}
-					} else {
-						label = "active"
-					}
-					break
-				}
+		if t, ok := scheduledTimerForEvent(ev, loc, occByChannelNumber, occByChannelID, numberByID, idByNumber, timersByID); ok {
+			active = true
+			if strings.TrimSpace(t.Title) != "" {
+				label = t.Title
+			} else {
+				label = "active"
 			}
 		}
 
@@ -1401,21 +1246,201 @@ func (h *Handler) EPGSearchNew(w http.ResponseWriter, r *http.Request) {
 	h.renderTemplate(w, r, "epgsearch_edit.html", data)
 }
 
+func (h *Handler) renderEPGSearchRun(w http.ResponseWriter, r *http.Request, search config.EPGSearch, pageTitle, heading, formAction string) {
+	config.NormalizeEPGSearch(&search)
+	if err := config.ValidateEPGSearch(search); err != nil {
+		data := h.epgSearchFormData(r, search)
+		data["Error"] = "Invalid search: " + err.Error()
+		data["PageTitle"] = pageTitle
+		data["Heading"] = heading
+		data["FormAction"] = formAction
+		h.renderTemplate(w, r, "epgsearch_edit.html", data)
+		return
+	}
+
+	channels, chErr := h.epgService.GetChannels(r.Context())
+	if chErr != nil {
+		channels = []domain.Channel{}
+	}
+	order := make(map[string]int, len(channels))
+	nameByID := make(map[string]string, len(channels))
+	numberByID := make(map[string]int, len(channels))
+	idByNumber := make(map[int]string, len(channels))
+	for i, ch := range channels {
+		if ch.ID != "" {
+			order[ch.ID] = i + 1
+			nameByID[ch.ID] = ch.Name
+			numberByID[ch.ID] = ch.Number
+		}
+		if ch.Number > 0 && ch.ID != "" {
+			idByNumber[ch.Number] = ch.ID
+		}
+	}
+
+	allEvents, err := h.epgService.GetEPG(r.Context(), "", time.Time{})
+	if err != nil {
+		data := h.epgSearchFormData(r, search)
+		data["Error"] = err.Error()
+		data["PageTitle"] = pageTitle
+		data["Heading"] = heading
+		data["FormAction"] = formAction
+		h.renderTemplate(w, r, "epgsearch_edit.html", data)
+		return
+	}
+
+	matches, err := services.ExecuteSavedEPGSearch(allEvents, search, order)
+	if err != nil {
+		data := h.epgSearchFormData(r, search)
+		data["Error"] = "Invalid search: " + err.Error()
+		data["PageTitle"] = pageTitle
+		data["Heading"] = heading
+		data["FormAction"] = formAction
+		h.renderTemplate(w, r, "epgsearch_edit.html", data)
+		return
+	}
+
+	// Build timer occurrences for the relevant event window.
+	timersByID := map[int]domain.Timer{}
+	occByChannelNumber := map[int][]timerOccurrence{}
+	occByChannelID := map[string][]timerOccurrence{}
+	if h.timerService != nil {
+		timers, tErr := h.timerService.GetAllTimers(r.Context())
+		if tErr != nil {
+			h.logger.Warn("timers fetch error for epgsearch run", slog.Any("error", tErr))
+		} else {
+			for _, t := range timers {
+				if strings.TrimSpace(t.ChannelID) == "" {
+					continue
+				}
+				timersByID[t.ID] = t
+			}
+		}
+	}
+
+	loc := time.Local
+	if len(timersByID) > 0 && len(matches) > 0 {
+		minStart := matches[0].Start.In(loc)
+		maxStop := matches[0].Stop.In(loc)
+		for i := 1; i < len(matches); i++ {
+			s := matches[i].Start.In(loc)
+			e := matches[i].Stop.In(loc)
+			if s.Before(minStart) {
+				minStart = s
+			}
+			if e.After(maxStop) {
+				maxStop = e
+			}
+		}
+		from := minStart.Add(-24 * time.Hour)
+		to := maxStop.Add(24 * time.Hour)
+		for _, t := range timersByID {
+			occs := timerOccurrences(t, from, to)
+			if t.ChannelID != "" {
+				occByChannelID[t.ChannelID] = append(occByChannelID[t.ChannelID], occs...)
+			}
+			timerChNum := 0
+			if n, err := strconv.Atoi(strings.TrimSpace(t.ChannelID)); err == nil {
+				timerChNum = n
+			} else if n := numberByID[t.ChannelID]; n > 0 {
+				timerChNum = n
+			}
+			if timerChNum > 0 {
+				occByChannelNumber[timerChNum] = append(occByChannelNumber[timerChNum], occs...)
+			}
+		}
+		for ch := range occByChannelID {
+			occs := occByChannelID[ch]
+			sort.SliceStable(occs, func(i, j int) bool {
+				if occs[i].Start.Equal(occs[j].Start) {
+					return occs[i].TimerID < occs[j].TimerID
+				}
+				return occs[i].Start.Before(occs[j].Start)
+			})
+			occByChannelID[ch] = occs
+		}
+		for n := range occByChannelNumber {
+			occs := occByChannelNumber[n]
+			sort.SliceStable(occs, func(i, j int) bool {
+				if occs[i].Start.Equal(occs[j].Start) {
+					return occs[i].TimerID < occs[j].TimerID
+				}
+				return occs[i].Start.Before(occs[j].Start)
+			})
+			occByChannelNumber[n] = occs
+		}
+	}
+
+	sort.SliceStable(matches, func(i, j int) bool {
+		a := matches[i].Start.In(loc)
+		b := matches[j].Start.In(loc)
+		if !a.Equal(b) {
+			return a.Before(b)
+		}
+		return matches[i].ChannelNumber < matches[j].ChannelNumber
+	})
+
+	dayGroups := []epgSearchResultDayGroup{}
+	var currentDay time.Time
+	var currentIdx int
+	for _, ev := range matches {
+		start := ev.Start.In(loc)
+		evDay := time.Date(start.Year(), start.Month(), start.Day(), 0, 0, 0, 0, loc)
+		if len(dayGroups) == 0 || !evDay.Equal(currentDay) {
+			dayGroups = append(dayGroups, epgSearchResultDayGroup{
+				DayLabel: start.Format("Monday, 01/02/2006"),
+				Events:   []epgSearchResultEventView{},
+			})
+			currentDay = evDay
+			currentIdx = len(dayGroups) - 1
+		}
+
+		if ev.ChannelNumber <= 0 && strings.TrimSpace(ev.ChannelID) != "" {
+			ev.ChannelNumber = numberByID[ev.ChannelID]
+		}
+		if strings.TrimSpace(ev.ChannelName) == "" && strings.TrimSpace(ev.ChannelID) != "" {
+			ev.ChannelName = nameByID[ev.ChannelID]
+		}
+		_, active := scheduledTimerForEvent(ev, loc, occByChannelNumber, occByChannelID, numberByID, idByNumber, timersByID)
+
+		dayGroups[currentIdx].Events = append(dayGroups[currentIdx].Events, epgSearchResultEventView{
+			EPGEvent:    ev,
+			TimerActive: active,
+			TimerLabel:  "",
+		})
+	}
+
+	data := h.epgSearchFormData(r, search)
+	data["PageTitle"] = pageTitle
+	data["Heading"] = heading
+	data["FormAction"] = formAction
+	data["RunDayGroups"] = dayGroups
+	h.renderTemplate(w, r, "epgsearch_edit.html", data)
+}
+
 func (h *Handler) EPGSearchCreate(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
-		return
-	}
-	if h.cfg == nil {
-		http.Error(w, "Configuration not available", http.StatusInternalServerError)
 		return
 	}
 	if err := r.ParseForm(); err != nil {
 		http.Error(w, "Invalid form", http.StatusBadRequest)
 		return
 	}
+	action := strings.TrimSpace(r.PostForm.Get("action"))
 
 	search := parseEPGSearchFromForm(r.PostForm)
+
+	// "Run" executes the search without saving and re-renders the form with matches.
+	if action == "run" {
+		h.renderEPGSearchRun(w, r, search, "Add New Search - VDRAdmin-go", "Add New Search", "/epgsearch/new")
+		return
+	}
+
+	if h.cfg == nil {
+		http.Error(w, "Configuration not available", http.StatusInternalServerError)
+		return
+	}
+
 	search.ID = nextEPGSearchID(h.cfg.EPG.Searches)
 
 	updated := *h.cfg
@@ -1477,14 +1502,11 @@ func (h *Handler) EPGSearchUpdate(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
-	if h.cfg == nil {
-		http.Error(w, "Configuration not available", http.StatusInternalServerError)
-		return
-	}
 	if err := r.ParseForm(); err != nil {
 		http.Error(w, "Invalid form", http.StatusBadRequest)
 		return
 	}
+	action := strings.TrimSpace(r.PostForm.Get("action"))
 
 	search := parseEPGSearchFromForm(r.PostForm)
 	if v := strings.TrimSpace(r.PostForm.Get("id")); v != "" {
@@ -1493,6 +1515,17 @@ func (h *Handler) EPGSearchUpdate(w http.ResponseWriter, r *http.Request) {
 	}
 	if search.ID <= 0 {
 		http.Error(w, "Invalid search id", http.StatusBadRequest)
+		return
+	}
+
+	// "Run" executes the (edited) search without saving and re-renders the form with matches.
+	if action == "run" {
+		h.renderEPGSearchRun(w, r, search, "Edit Search - VDRAdmin-go", "Edit Search", "/epgsearch/edit")
+		return
+	}
+
+	if h.cfg == nil {
+		http.Error(w, "Configuration not available", http.StatusInternalServerError)
 		return
 	}
 
@@ -1875,6 +1908,90 @@ func timerOccurrences(t domain.Timer, from, to time.Time) []timerOccurrence {
 	return out
 }
 
+func normalizeTitleForTimerMatch(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	s = strings.Join(strings.Fields(s), " ")
+	return s
+}
+
+func scheduledTimerForEvent(
+	ev domain.EPGEvent,
+	loc *time.Location,
+	occByChannelNumber map[int][]timerOccurrence,
+	occByChannelID map[string][]timerOccurrence,
+	numberByID map[string]int,
+	idByNumber map[int]string,
+	timersByID map[int]domain.Timer,
+) (domain.Timer, bool) {
+	if loc == nil {
+		loc = time.Local
+	}
+
+	evTitle := normalizeTitleForTimerMatch(ev.Title)
+	if evTitle == "" {
+		return domain.Timer{}, false
+	}
+
+	lookupOccs := func() []timerOccurrence {
+		if ev.ChannelNumber > 0 {
+			if occs := occByChannelNumber[ev.ChannelNumber]; len(occs) > 0 {
+				return occs
+			}
+		}
+		if ev.ChannelID != "" {
+			if ev.ChannelNumber <= 0 {
+				if n := numberByID[ev.ChannelID]; n > 0 {
+					if occs := occByChannelNumber[n]; len(occs) > 0 {
+						return occs
+					}
+				}
+			}
+			if occs := occByChannelID[ev.ChannelID]; len(occs) > 0 {
+				return occs
+			}
+			if ev.ChannelNumber > 0 {
+				if occs := occByChannelID[strconv.Itoa(ev.ChannelNumber)]; len(occs) > 0 {
+					return occs
+				}
+			}
+		}
+		if ev.ChannelNumber > 0 {
+			if id := idByNumber[ev.ChannelNumber]; id != "" {
+				if occs := occByChannelID[id]; len(occs) > 0 {
+					return occs
+				}
+			}
+		}
+		return nil
+	}
+
+	occs := lookupOccs()
+	if len(occs) == 0 {
+		return domain.Timer{}, false
+	}
+
+	evStart := ev.Start.In(loc)
+	evStop := ev.Stop.In(loc)
+	if evStop.Before(evStart) {
+		evStop = evStart
+	}
+
+	for _, occ := range occs {
+		if !occ.Start.Before(evStop) || !evStart.Before(occ.Stop) {
+			continue
+		}
+		t, ok := timersByID[occ.TimerID]
+		if !ok {
+			continue
+		}
+		if normalizeTitleForTimerMatch(t.Title) == evTitle {
+			return t, true
+		}
+	}
+
+	return domain.Timer{}, false
+}
+
 func isWeekdayMaskHTTP(daySpec string) bool {
 	daySpec = strings.TrimSpace(daySpec)
 	if len(daySpec) != 7 {
@@ -1966,6 +2083,31 @@ func (h *Handler) TimerNew(w http.ResponseWriter, r *http.Request) {
 	}
 
 	model, selectedChannel := h.timerNewFormModel(time.Now(), channels)
+
+	// Optional prefill (used by EPG search "Record" links).
+	q := r.URL.Query()
+	if v := strings.TrimSpace(q.Get("channel")); v != "" {
+		model.ChannelID = v
+		selectedChannel = v
+	}
+	if v := strings.TrimSpace(q.Get("day")); v != "" {
+		if _, err := time.ParseInLocation("2006-01-02", v, time.Local); err == nil {
+			model.Day = v
+		}
+	}
+	if v := strings.TrimSpace(q.Get("start")); v != "" {
+		if _, err := time.Parse("15:04", v); err == nil {
+			model.Start = v
+		}
+	}
+	if v := strings.TrimSpace(q.Get("stop")); v != "" {
+		if _, err := time.Parse("15:04", v); err == nil {
+			model.Stop = v
+		}
+	}
+	if v := strings.TrimSpace(q.Get("title")); v != "" {
+		model.Title = v
+	}
 	data := map[string]any{
 		"PageTitle":       "New Timer - VDRAdmin-go",
 		"Heading":         "New Timer",
@@ -2300,65 +2442,6 @@ func (h *Handler) TimerCreate(w http.ResponseWriter, r *http.Request) {
 			}
 			if channelID != "" && event.ChannelID != channelID {
 				continue
-			}
-
-			// Guard against duplicate timers: if an existing timer overlaps the event window
-			// on the same channel *and matches the event title*, treat it as already scheduled.
-			if h.timerService != nil {
-				existing, tErr := h.timerService.GetAllTimers(r.Context())
-				if tErr == nil {
-					normalizeTitle := func(s string) string {
-						s = strings.ToLower(strings.TrimSpace(s))
-						s = strings.Join(strings.Fields(s), " ")
-						return s
-					}
-					evTitle := normalizeTitle(event.Title)
-					for _, t := range existing {
-						if strings.TrimSpace(t.ChannelID) == "" {
-							continue
-						}
-						sameChannel := false
-						if channelID != "" {
-							sameChannel = (strings.TrimSpace(t.ChannelID) == strings.TrimSpace(channelID))
-						}
-						if !sameChannel {
-							// Try numeric channel match when timer uses channel number.
-							if event.ChannelNumber > 0 {
-								if n, err := strconv.Atoi(strings.TrimSpace(t.ChannelID)); err == nil && n == event.ChannelNumber {
-									sameChannel = true
-								}
-							}
-						}
-						if !sameChannel {
-							continue
-						}
-						if evTitle == "" || normalizeTitle(t.Title) != evTitle {
-							continue
-						}
-
-						evStart := event.Start.In(time.Local)
-						evStop := event.Stop.In(time.Local)
-						if evStop.Before(evStart) {
-							evStop = evStart
-						}
-						// Timer overlap check: start < stop && evStart < timerStop
-						for _, occ := range timerOccurrences(t, evStart.Add(-24*time.Hour), evStop.Add(24*time.Hour)) {
-							if occ.Start.Before(evStop) && evStart.Before(occ.Stop) {
-								// Redirect back with a message instead of creating a duplicate.
-								ref := r.Referer()
-								if ref == "" {
-									ref = "/timers"
-								}
-								sep := "?"
-								if strings.Contains(ref, "?") {
-									sep = "&"
-								}
-								http.Redirect(w, r, ref+sep+"msg="+url.QueryEscape("Timer already exists for this show."), http.StatusSeeOther)
-								return
-							}
-						}
-					}
-				}
 			}
 
 			priority, lifetime, marginStart, marginEnd := h.timerDefaults()

--- a/internal/adapters/primary/http/handlers.go
+++ b/internal/adapters/primary/http/handlers.go
@@ -2633,7 +2633,7 @@ func normalizeTheme(theme string) string {
 	}
 }
 
-func themeFromRequest(r *http.Request, fallback string) string {
+func themeFromRequest(_ *http.Request, fallback string) string {
 	// The UI theme is configured server-side (Configurations page) and should apply
 	// consistently across all pages. Ignore any legacy per-browser theme cookie.
 	return normalizeTheme(fallback)

--- a/internal/adapters/primary/http/handlers.go
+++ b/internal/adapters/primary/http/handlers.go
@@ -166,7 +166,9 @@ func (h *Handler) Channels(w http.ResponseWriter, r *http.Request) {
 	// Always include selected day in the dropdown.
 	daysByValue[dayStart.Format("2006-01-02")] = dayStart
 	if selected != "" {
-		ev, err := h.epgService.GetEPG(r.Context(), selected, time.Now())
+		// Anchor the EPG request to the selected day. Using time.Now() here causes
+		// inconsistent behavior across day selections (and cache keys).
+		ev, err := h.epgService.GetEPG(r.Context(), selected, dayStart)
 		if err != nil {
 			h.logger.Error("EPG fetch error on channels", slog.Any("error", err), slog.String("channel", selected))
 			data["HomeError"] = err.Error()

--- a/internal/adapters/primary/http/playing_record_button_test.go
+++ b/internal/adapters/primary/http/playing_record_button_test.go
@@ -1,0 +1,146 @@
+package http
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"html/template"
+
+	"github.com/githubixx/vdradmin-go/internal/application/services"
+	"github.com/githubixx/vdradmin-go/internal/domain"
+)
+
+type playingVDRMock struct {
+	channels []domain.Channel
+	epqErr   error
+	epq      []domain.EPGEvent
+	timers   []domain.Timer
+}
+
+func (m *playingVDRMock) Connect(ctx context.Context) error { return nil }
+func (m *playingVDRMock) Close() error                      { return nil }
+func (m *playingVDRMock) Ping(ctx context.Context) error    { return nil }
+
+func (m *playingVDRMock) GetChannels(ctx context.Context) ([]domain.Channel, error) {
+	return m.channels, nil
+}
+
+func (m *playingVDRMock) GetEPG(ctx context.Context, channelID string, at time.Time) ([]domain.EPGEvent, error) {
+	if m.epqErr != nil {
+		return nil, m.epqErr
+	}
+	return m.epq, nil
+}
+
+func (m *playingVDRMock) GetTimers(ctx context.Context) ([]domain.Timer, error) { return m.timers, nil }
+
+func (m *playingVDRMock) CreateTimer(ctx context.Context, timer *domain.Timer) error { return nil }
+func (m *playingVDRMock) UpdateTimer(ctx context.Context, timer *domain.Timer) error { return nil }
+func (m *playingVDRMock) DeleteTimer(ctx context.Context, timerID int) error         { return nil }
+
+func (m *playingVDRMock) GetRecordings(ctx context.Context) ([]domain.Recording, error) {
+	return nil, nil
+}
+func (m *playingVDRMock) DeleteRecording(ctx context.Context, path string) error { return nil }
+func (m *playingVDRMock) GetCurrentChannel(ctx context.Context) (string, error)  { return "", nil }
+func (m *playingVDRMock) SetCurrentChannel(ctx context.Context, channelID string) error {
+	return nil
+}
+func (m *playingVDRMock) SendKey(ctx context.Context, key string) error { return nil }
+
+func TestPlayingToday_DisablesRecordWhenTimerExists(t *testing.T) {
+	loc := time.Local
+	day := time.Date(2026, 1, 4, 0, 0, 0, 0, loc)
+
+	ch := domain.Channel{ID: "C-1-2-3", Number: 1, Name: "Test Channel"}
+	ev := domain.EPGEvent{
+		EventID:       123,
+		ChannelID:     ch.ID,
+		ChannelNumber: ch.Number,
+		ChannelName:   ch.Name,
+		Title:         "Test Show",
+		Start:         day.Add(10 * time.Hour),
+		Stop:          day.Add(11 * time.Hour),
+	}
+	t := domain.Timer{
+		ID:        1,
+		Active:    true,
+		ChannelID: ch.ID,
+		Title:     "Test Show",
+		Start:     ev.Start.Add(-2 * time.Minute),
+		Stop:      ev.Stop.Add(10 * time.Minute),
+	}
+	// Adjacent show that overlaps the timer window by margin only.
+	adjacent := ev
+	adjacent.EventID = 124
+	adjacent.Title = "Other Show"
+	adjacent.Start = day.Add(9*time.Hour + 55*time.Minute)
+	adjacent.Stop = day.Add(10 * time.Hour)
+
+	// Common real-world case: the EPG event has no ChannelNumber populated,
+	// and timers reference channels by number string.
+	evMissingNumber := ev
+	evMissingNumber.EventID = 456
+	evMissingNumber.ChannelNumber = 0
+	evMissingNumber.ChannelName = ""
+	tNumericChannel := t
+	tNumericChannel.ID = 2
+	tNumericChannel.ChannelID = "1"
+
+	mock := &playingVDRMock{
+		channels: []domain.Channel{ch},
+		epq:      []domain.EPGEvent{ev, adjacent, evMissingNumber},
+		timers:   []domain.Timer{t, tNumericChannel},
+	}
+
+	epqService := services.NewEPGService(mock, 0)
+	timerService := services.NewTimerService(mock)
+
+	parsed := template.Must(template.ParseFiles(
+		filepath.Join(repoRoot(t), "web", "templates", "_nav.html"),
+		filepath.Join(repoRoot(t), "web", "templates", "playing.html"),
+	))
+
+	h := NewHandler(
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+		parsed,
+		epqService,
+		timerService,
+		nil,
+		nil,
+	)
+	h.SetUIThemeDefault("light")
+	h.SetTemplates(map[string]*template.Template{"playing.html": parsed})
+
+	req := httptest.NewRequest(http.MethodGet, "/playing?day=2026-01-04", nil)
+	ctx := context.WithValue(req.Context(), "user", "admin")
+	ctx = context.WithValue(ctx, "role", "admin")
+	req = req.WithContext(ctx)
+
+	rw := httptest.NewRecorder()
+	h.PlayingToday(rw, req)
+
+	if rw.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rw.Code)
+	}
+
+	body := rw.Body.String()
+	if !strings.Contains(body, "class=\"btn btn-sm btn-secondary\" disabled>Scheduled</button>") {
+		t.Fatalf("expected disabled Record button when timer exists")
+	}
+	// The matching show should not render the create form.
+	if strings.Contains(body, "<form method=\"post\" action=\"/timers/create\"") && strings.Contains(body, "Test Show") {
+		t.Fatalf("did not expect timers/create form when timer exists")
+	}
+	// Adjacent show should still offer Record.
+	if !strings.Contains(body, "Other Show") || !strings.Contains(body, "<form method=\"post\" action=\"/timers/create\"") {
+		t.Fatalf("expected adjacent show to still be recordable")
+	}
+}

--- a/internal/adapters/primary/http/timer_new_prefill_test.go
+++ b/internal/adapters/primary/http/timer_new_prefill_test.go
@@ -1,0 +1,108 @@
+package http
+
+import (
+	"context"
+	"html/template"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/githubixx/vdradmin-go/internal/application/services"
+	"github.com/githubixx/vdradmin-go/internal/domain"
+)
+
+type timerNewPrefillVDRMock struct {
+	channels []domain.Channel
+}
+
+func (m *timerNewPrefillVDRMock) Connect(ctx context.Context) error { return nil }
+func (m *timerNewPrefillVDRMock) Close() error                      { return nil }
+func (m *timerNewPrefillVDRMock) Ping(ctx context.Context) error    { return nil }
+
+func (m *timerNewPrefillVDRMock) GetChannels(ctx context.Context) ([]domain.Channel, error) {
+	return m.channels, nil
+}
+
+func (m *timerNewPrefillVDRMock) GetEPG(ctx context.Context, channelID string, at time.Time) ([]domain.EPGEvent, error) {
+	return []domain.EPGEvent{}, nil
+}
+
+func (m *timerNewPrefillVDRMock) GetTimers(ctx context.Context) ([]domain.Timer, error) {
+	return []domain.Timer{}, nil
+}
+
+func (m *timerNewPrefillVDRMock) CreateTimer(ctx context.Context, timer *domain.Timer) error {
+	return nil
+}
+func (m *timerNewPrefillVDRMock) UpdateTimer(ctx context.Context, timer *domain.Timer) error {
+	return nil
+}
+func (m *timerNewPrefillVDRMock) DeleteTimer(ctx context.Context, timerID int) error { return nil }
+
+func (m *timerNewPrefillVDRMock) GetRecordings(ctx context.Context) ([]domain.Recording, error) {
+	return nil, nil
+}
+func (m *timerNewPrefillVDRMock) DeleteRecording(ctx context.Context, path string) error { return nil }
+func (m *timerNewPrefillVDRMock) GetCurrentChannel(ctx context.Context) (string, error) {
+	return "", nil
+}
+func (m *timerNewPrefillVDRMock) SetCurrentChannel(ctx context.Context, channelID string) error {
+	return nil
+}
+func (m *timerNewPrefillVDRMock) SendKey(ctx context.Context, key string) error { return nil }
+
+func TestTimerNew_PrefillsFromQueryParams(t *testing.T) {
+	ch := domain.Channel{ID: "C-1-2-3", Number: 1, Name: "SWR BW HD"}
+	mock := &timerNewPrefillVDRMock{channels: []domain.Channel{ch}}
+
+	epqService := services.NewEPGService(mock, 0)
+
+	parsed := template.Must(template.ParseFiles(
+		filepath.Join(repoRoot(t), "web", "templates", "_nav.html"),
+		filepath.Join(repoRoot(t), "web", "templates", "timer_edit.html"),
+	))
+
+	h := NewHandler(
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+		parsed,
+		epqService,
+		nil,
+		nil,
+		nil,
+	)
+	h.SetUIThemeDefault("light")
+	h.SetTemplates(map[string]*template.Template{"timer_edit.html": parsed})
+
+	req := httptest.NewRequest(http.MethodGet, "/timers/new?channel=C-1-2-3&day=2026-01-07&start=00:00&stop=01:30&title=Familie+Heinz+Becker+-+Lachgeschichten", nil)
+	ctx := context.WithValue(req.Context(), "user", "admin")
+	ctx = context.WithValue(ctx, "role", "admin")
+	req = req.WithContext(ctx)
+
+	rw := httptest.NewRecorder()
+	h.TimerNew(rw, req)
+
+	if rw.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rw.Code)
+	}
+	body := rw.Body.String()
+	if !strings.Contains(body, "value=\"2026-01-07\"") {
+		t.Fatalf("expected day to be prefilled")
+	}
+	if !strings.Contains(body, "name=\"start\" value=\"00:00\"") {
+		t.Fatalf("expected start to be prefilled")
+	}
+	if !strings.Contains(body, "name=\"stop\" value=\"01:30\"") {
+		t.Fatalf("expected stop to be prefilled")
+	}
+	if !strings.Contains(body, "name=\"title\" value=\"Familie Heinz Becker - Lachgeschichten\"") {
+		t.Fatalf("expected title to be prefilled")
+	}
+	if !strings.Contains(body, "<option value=\"C-1-2-3\" selected>") {
+		t.Fatalf("expected channel to be selected")
+	}
+}

--- a/internal/adapters/secondary/svdrp/client.go
+++ b/internal/adapters/secondary/svdrp/client.go
@@ -829,19 +829,19 @@ func parseTimer(line string) (domain.Timer, error) {
 	}
 
 	return domain.Timer{
-		ID:        timerID,
-		Active:    active,
-		ChannelID: fields[1],
-		Day:       day,
-		Start:     startTime,
-		Stop:      stopTime,
-		DaySpec:   daySpec,
+		ID:           timerID,
+		Active:       active,
+		ChannelID:    fields[1],
+		Day:          day,
+		Start:        startTime,
+		Stop:         stopTime,
+		DaySpec:      daySpec,
 		StartMinutes: startClock,
 		StopMinutes:  stopClock,
-		Priority:  priority,
-		Lifetime:  lifetime,
-		Title:     title,
-		Aux:       aux,
+		Priority:     priority,
+		Lifetime:     lifetime,
+		Title:        title,
+		Aux:          aux,
 	}, nil
 }
 

--- a/internal/application/services/epg_saved_search.go
+++ b/internal/application/services/epg_saved_search.go
@@ -4,7 +4,6 @@ import (
 	"regexp"
 	"sort"
 	"strings"
-	"time"
 
 	"github.com/githubixx/vdradmin-go/internal/domain"
 	"github.com/githubixx/vdradmin-go/internal/infrastructure/config"
@@ -144,40 +143,4 @@ func savedSearchChannelMatches(ev domain.EPGEvent, search config.EPGSearch, orde
 	default:
 		return true
 	}
-}
-
-// parseHHMM parses "HH:MM" in local time for comparisons; returns minutes since midnight.
-func parseHHMM(s string) (int, bool) {
-	parts := strings.Split(strings.TrimSpace(s), ":")
-	if len(parts) != 2 {
-		return 0, false
-	}
-	// Avoid strconv import here; tiny parser.
-	toInt := func(x string) (int, bool) {
-		if x == "" {
-			return 0, false
-		}
-		v := 0
-		for i := 0; i < len(x); i++ {
-			if x[i] < '0' || x[i] > '9' {
-				return 0, false
-			}
-			v = v*10 + int(x[i]-'0')
-		}
-		return v, true
-	}
-	h, ok := toInt(parts[0])
-	if !ok || h < 0 || h > 23 {
-		return 0, false
-	}
-	m, ok := toInt(parts[1])
-	if !ok || m < 0 || m > 59 {
-		return 0, false
-	}
-	return h*60 + m, true
-}
-
-func minutesSinceMidnight(t time.Time) int {
-	lt := t.In(time.Local)
-	return lt.Hour()*60 + lt.Minute()
 }

--- a/internal/application/services/timer_service_midnight_test.go
+++ b/internal/application/services/timer_service_midnight_test.go
@@ -1,0 +1,77 @@
+package services
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/githubixx/vdradmin-go/internal/domain"
+)
+
+type timerCreateSpyVDR struct {
+	created *domain.Timer
+}
+
+func (s *timerCreateSpyVDR) Connect(ctx context.Context) error { return nil }
+func (s *timerCreateSpyVDR) Close() error                      { return nil }
+func (s *timerCreateSpyVDR) Ping(ctx context.Context) error    { return nil }
+
+func (s *timerCreateSpyVDR) GetChannels(ctx context.Context) ([]domain.Channel, error) { return nil, nil }
+func (s *timerCreateSpyVDR) GetEPG(ctx context.Context, channelID string, at time.Time) ([]domain.EPGEvent, error) {
+	return nil, nil
+}
+func (s *timerCreateSpyVDR) GetTimers(ctx context.Context) ([]domain.Timer, error) { return nil, nil }
+
+func (s *timerCreateSpyVDR) CreateTimer(ctx context.Context, timer *domain.Timer) error {
+	cpy := *timer
+	s.created = &cpy
+	return nil
+}
+func (s *timerCreateSpyVDR) UpdateTimer(ctx context.Context, timer *domain.Timer) error { return nil }
+func (s *timerCreateSpyVDR) DeleteTimer(ctx context.Context, timerID int) error         { return nil }
+
+func (s *timerCreateSpyVDR) GetRecordings(ctx context.Context) ([]domain.Recording, error) { return nil, nil }
+func (s *timerCreateSpyVDR) DeleteRecording(ctx context.Context, path string) error         { return nil }
+func (s *timerCreateSpyVDR) GetCurrentChannel(ctx context.Context) (string, error)         { return "", nil }
+func (s *timerCreateSpyVDR) SetCurrentChannel(ctx context.Context, channelID string) error { return nil }
+func (s *timerCreateSpyVDR) SendKey(ctx context.Context, key string) error                 { return nil }
+
+func TestCreateTimerFromEPG_MidnightMarginAdjustsDay(t *testing.T) {
+	loc := time.Local
+	// Event starts at midnight; marginStart pushes timer start into previous day.
+	eventStart := time.Date(2026, 1, 7, 0, 0, 0, 0, loc)
+	eventStop := time.Date(2026, 1, 7, 1, 30, 0, 0, loc)
+
+	event := domain.EPGEvent{
+		EventID:   123,
+		ChannelID: "C-1-2-3",
+		Title:     "Familie Heinz Becker - Lachgeschichten",
+		Start:     eventStart,
+		Stop:      eventStop,
+	}
+
+	spy := &timerCreateSpyVDR{}
+	svc := NewTimerService(spy)
+
+	marginStart := 2
+	marginEnd := 10
+	if err := svc.CreateTimerFromEPG(context.Background(), event, 50, 99, marginStart, marginEnd); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if spy.created == nil {
+		t.Fatalf("expected CreateTimer to be called")
+	}
+
+	expectedStart := eventStart.Add(-2 * time.Minute)
+	expectedDay := time.Date(expectedStart.Year(), expectedStart.Month(), expectedStart.Day(), 0, 0, 0, 0, loc)
+
+	if !spy.created.Start.Equal(expectedStart) {
+		t.Fatalf("expected timer start %s, got %s", expectedStart.Format(time.RFC3339), spy.created.Start.Format(time.RFC3339))
+	}
+	if !spy.created.Day.Equal(expectedDay) {
+		t.Fatalf("expected timer day %s, got %s", expectedDay.Format("2006-01-02"), spy.created.Day.Format("2006-01-02"))
+	}
+	if !spy.created.Stop.Equal(eventStop.Add(10 * time.Minute)) {
+		t.Fatalf("expected timer stop %s, got %s", eventStop.Add(10*time.Minute).Format(time.RFC3339), spy.created.Stop.Format(time.RFC3339))
+	}
+}

--- a/internal/application/services/timer_service_midnight_test.go
+++ b/internal/application/services/timer_service_midnight_test.go
@@ -16,7 +16,9 @@ func (s *timerCreateSpyVDR) Connect(ctx context.Context) error { return nil }
 func (s *timerCreateSpyVDR) Close() error                      { return nil }
 func (s *timerCreateSpyVDR) Ping(ctx context.Context) error    { return nil }
 
-func (s *timerCreateSpyVDR) GetChannels(ctx context.Context) ([]domain.Channel, error) { return nil, nil }
+func (s *timerCreateSpyVDR) GetChannels(ctx context.Context) ([]domain.Channel, error) {
+	return nil, nil
+}
 func (s *timerCreateSpyVDR) GetEPG(ctx context.Context, channelID string, at time.Time) ([]domain.EPGEvent, error) {
 	return nil, nil
 }
@@ -30,11 +32,15 @@ func (s *timerCreateSpyVDR) CreateTimer(ctx context.Context, timer *domain.Timer
 func (s *timerCreateSpyVDR) UpdateTimer(ctx context.Context, timer *domain.Timer) error { return nil }
 func (s *timerCreateSpyVDR) DeleteTimer(ctx context.Context, timerID int) error         { return nil }
 
-func (s *timerCreateSpyVDR) GetRecordings(ctx context.Context) ([]domain.Recording, error) { return nil, nil }
-func (s *timerCreateSpyVDR) DeleteRecording(ctx context.Context, path string) error         { return nil }
-func (s *timerCreateSpyVDR) GetCurrentChannel(ctx context.Context) (string, error)         { return "", nil }
-func (s *timerCreateSpyVDR) SetCurrentChannel(ctx context.Context, channelID string) error { return nil }
-func (s *timerCreateSpyVDR) SendKey(ctx context.Context, key string) error                 { return nil }
+func (s *timerCreateSpyVDR) GetRecordings(ctx context.Context) ([]domain.Recording, error) {
+	return nil, nil
+}
+func (s *timerCreateSpyVDR) DeleteRecording(ctx context.Context, path string) error { return nil }
+func (s *timerCreateSpyVDR) GetCurrentChannel(ctx context.Context) (string, error)  { return "", nil }
+func (s *timerCreateSpyVDR) SetCurrentChannel(ctx context.Context, channelID string) error {
+	return nil
+}
+func (s *timerCreateSpyVDR) SendKey(ctx context.Context, key string) error { return nil }
 
 func TestCreateTimerFromEPG_MidnightMarginAdjustsDay(t *testing.T) {
 	loc := time.Local

--- a/internal/domain/models.go
+++ b/internal/domain/models.go
@@ -57,11 +57,11 @@ type Timer struct {
 	// These are required for recurring timers where Start/Stop may be computed relative to a projected day.
 	StartMinutes int
 	StopMinutes  int
-	Priority  int
-	Lifetime  int // days to keep recording
-	Title     string
-	Aux       string
-	EventID   int
+	Priority     int
+	Lifetime     int // days to keep recording
+	Title        string
+	Aux          string
+	EventID      int
 }
 
 // Recording represents a completed recording

--- a/web/static/js/theme.js
+++ b/web/static/js/theme.js
@@ -50,3 +50,5 @@
     if (mq.addEventListener) mq.addEventListener('change', handler);
     else if (mq.addListener) mq.addListener(handler);
   }
+
+})();

--- a/web/templates/channels.html
+++ b/web/templates/channels.html
@@ -65,11 +65,15 @@
                     <a class="btn btn-sm btn-secondary" href="/event?channel={{.ChannelID}}&id={{.EventID}}" onclick="window.open(this.href,'vdradmin_moreinfo','width=560,height=420,scrollbars=yes,resizable=yes'); return false;">More information</a>
                     {{end}}
                     {{if eq $.Role "admin"}}
+                    {{if or .TimerActive (le .EventID 0)}}
+                    <button type="button" class="btn btn-sm btn-secondary" disabled>Scheduled</button>
+                    {{else}}
                     <form method="post" action="/timers/create" class="inline-form">
                         <input type="hidden" name="event_id" value="{{.EventID}}" />
                         <input type="hidden" name="channel" value="{{.ChannelID}}" />
                         <button type="submit" class="btn btn-sm btn-primary">Record</button>
                     </form>
+                    {{end}}
                     {{end}}
                 </div>
             </div>

--- a/web/templates/epgsearch_edit.html
+++ b/web/templates/epgsearch_edit.html
@@ -89,11 +89,52 @@
 
                 <div></div>
                 <div class="timer-form-actions">
-                    <button type="submit" class="btn btn-primary">Save</button>
+                    <button type="submit" name="action" value="save" class="btn btn-primary">Save</button>
+                    {{if or (eq .FormAction "/epgsearch/new") (eq .FormAction "/epgsearch/edit")}}
+                    <button type="submit" name="action" value="run" class="btn btn-secondary">Run</button>
+                    {{end}}
                     <a href="/epgsearch" class="btn btn-secondary">Cancel</a>
                 </div>
             </form>
         </div>
+
+        {{if .RunDayGroups}}
+        <div class="toolbar">
+            <h3>Matches</h3>
+        </div>
+        {{range .RunDayGroups}}
+        <div class="channels-day">{{.DayLabel}}</div>
+        <div class="epg-list">
+            {{range .Events}}
+            <div class="epg-item">
+                <div class="epg-time">
+                    <time datetime="{{.Start.Format "2006-01-02T15:04"}}">{{.Start.Format "15:04"}}-{{.Stop.Format "15:04"}}</time>
+                </div>
+                <div class="epg-content">
+                    <div class="epg-header">
+                        <h4>{{.Title}}</h4>
+                        <span class="epg-channel">{{.ChannelName}}</span>
+                    </div>
+                    {{if .Subtitle}}
+                    <p class="epg-subtitle">{{.Subtitle}}</p>
+                    {{end}}
+                </div>
+                {{if eq $.Role "admin"}}
+                <div class="epg-actions">
+                    {{if or .TimerActive (le .EventID 0)}}
+                    <button type="button" class="btn btn-sm btn-secondary" disabled>Scheduled</button>
+                    {{else}}
+                    <a class="btn btn-sm btn-primary" href="/timers/new?channel={{.ChannelID | urlquery}}&day={{.Start.Format "2006-01-02"}}&start={{.Start.Format "15:04"}}&stop={{.Stop.Format "15:04"}}&title={{.Title | urlquery}}">Record</a>
+                    {{end}}
+                </div>
+                {{end}}
+            </div>
+            {{else}}
+            <p class="empty-state">No matches</p>
+            {{end}}
+        </div>
+        {{end}}
+        {{end}}
 
         <script>
             (function() {

--- a/web/templates/epgsearch_results.html
+++ b/web/templates/epgsearch_results.html
@@ -50,7 +50,7 @@
                         {{if eq $.Role "admin"}}
                         <td class="actions" style="text-align: right;">
                             {{if or .TimerActive (le .EventID 0)}}
-                            <button class="btn btn-sm btn-secondary" disabled>Record</button>
+                            <button class="btn btn-sm btn-secondary" disabled>Scheduled</button>
                             {{else}}
                             <button
                                 hx-post="/timers/create?channel={{.ChannelID}}&event_id={{.EventID}}"

--- a/web/templates/playing.html
+++ b/web/templates/playing.html
@@ -13,9 +13,21 @@
 
     <main class="container">
         <div class="toolbar">
-            <strong>{{.Day.Format "Mon 2006-01-02"}}</strong>
-            <a class="btn btn-secondary btn-menu" href="/playing?day={{.PrevDay}}">Previous day</a>
-            <a class="btn btn-secondary btn-menu" href="/playing?day={{.NextDay}}">Next day</a>
+            <div class="nav-channel-form">
+                <strong>{{.Day.Format "Mon 2006-01-02"}}</strong>
+
+                <div class="nav-select">
+                    <select id="channel-jump" name="channel-jump" onchange="if (this.value) { location.hash = this.value; }">
+                        <option value="">Select channel...</option>
+                        {{range .ChannelJump}}
+                        <option value="{{.Anchor}}">{{.Label}}</option>
+                        {{end}}
+                    </select>
+                </div>
+
+                <a class="btn btn-secondary btn-menu" href="/playing?day={{.PrevDay}}">Previous day</a>
+                <a class="btn btn-secondary btn-menu" href="/playing?day={{.NextDay}}">Next day</a>
+            </div>
         </div>
 
         {{if .HomeError}}
@@ -25,7 +37,7 @@
         {{end}}
 
         {{range .ChannelGroups}}
-        <div class="channels-day">{{.Channel.Name}}</div>
+        <div class="channels-day" id="{{.Anchor}}">{{.Channel.Name}}</div>
         <div class="epg-list">
             {{range .Events}}
             <div class="epg-item">

--- a/web/templates/playing.html
+++ b/web/templates/playing.html
@@ -45,11 +45,15 @@
                     <a class="btn btn-sm btn-secondary" href="/event?channel={{.ChannelID}}&id={{.EventID}}" onclick="window.open(this.href,'vdradmin_moreinfo','width=560,height=420,scrollbars=yes,resizable=yes'); return false;">More information</a>
                     {{end}}
                     {{if eq $.Role "admin"}}
+                    {{if or .TimerActive (le .EventID 0)}}
+                    <button type="button" class="btn btn-sm btn-secondary" disabled>Scheduled</button>
+                    {{else}}
                     <form method="post" action="/timers/create" class="inline-form">
                         <input type="hidden" name="event_id" value="{{.EventID}}" />
                         <input type="hidden" name="channel" value="{{.ChannelID}}" />
                         <button type="submit" class="btn btn-sm btn-primary">Record</button>
                     </form>
+                    {{end}}
                     {{end}}
                 </div>
             </div>


### PR DESCRIPTION
This PR improves EPG/timer UX and correctness across multiple pages, adds an interactive “Run” workflow for EPG saved searches (without saving), hardens/normalizes untrusted “Run” inputs, and includes a few small UI/cleanup fixes (theme handling, JS syntax, unused code).

## What changed

- **EPG Search: “Run” without saving**
  - Added a **Run** button to both **Add New Search** and **Edit Search** forms.
  - Running shows **matching EPG results inline**, grouped by day.
  - Each match offers a **Record** action that links to **/timers/new** with prefilled fields.
  - Matches that already have a timer are shown as **Scheduled** (disabled) for consistency with other pages.

- **Scheduled/Record correctness (incl. midnight edge case)**
  - Fixed a bug where shows around **midnight** could have an existing timer but were **not marked Scheduled** (notably on `/channels`).
  - Timer creation from EPG now computes the **timer day from the margin-adjusted start time**, so “00:00 with marginStart” correctly becomes the previous day in VDR’s day spec.

- **/playing usability**
  - Added a **channel jump dropdown** on `/playing` (next to the day navigation) to quickly jump to a channel section in long lists.

- **Theme + small fixes**
  - Removed legacy **theme cookie** behavior in favor of server-configured theme handling.
  - Fixed a **JS syntax issue** in the theme script (missing closing braces).
  - Removed unused helper functions and cleaned up minor lints.

## Tests

- Added/expanded unit tests covering:
  - `/channels` scheduled/record behavior (including midnight scenarios).
  - EPG Search “Run” behavior and rendering, including prefilled timer links.
  - Timer creation day calculation when margins cross day boundaries.
  - `/playing` rendering of the new channel jump dropdown.